### PR TITLE
Retries: Extend rejection delay, restore after

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -1590,7 +1590,7 @@ class OpenWeatherMenuButton extends PanelMenu.Button {
     });
   }
 
-  reloadWeatherCurrent(interval) {
+  reloadWeatherCurrent(interval, next_interval) {
     if (this._timeoutCurrent) {
       GLib.source_remove(this._timeoutCurrent);
       this._timeoutCurrent = null;
@@ -1601,6 +1601,8 @@ class OpenWeatherMenuButton extends PanelMenu.Button {
       interval,
       () => {
         this.refreshWeatherData().catch((e) => console.error(e));
+        if (next_interval !== null)
+          reloadWeatherCurrent(next_interval);
         return true;
       }
     );

--- a/src/openweathermap.js
+++ b/src/openweathermap.js
@@ -81,7 +81,7 @@ async function refreshWeatherData()
         if(tryAgain)
         {
           this._provUrlButton.label = getWeatherProviderName(this.weatherProvider);
-          this.reloadWeatherCurrent(1);
+          this.reloadWeatherCurrent(10, this._refresh_interval_current);
         }
         else
         {
@@ -98,7 +98,7 @@ async function refreshWeatherData()
     {
       console.warn("OpenWeather Refined: getWeatherInfo failed without an error.");
       // Try reloading after 10 minutes
-      this.reloadWeatherCurrent(600);
+      this.reloadWeatherCurrent(600, this._refresh_interval_current);
       return;
     }
 


### PR DESCRIPTION
- Extend the retry interval for rejected API requests (due to limits or other issues) from 1 second to 10 seconds.
- Add an optional second parameter to `reloadWeatherCurrent()` that, if set, will be the interval that's set to the timer _after_ the current interval next expires. (This is so that short-interval retries will occur only once, and the normal timer period restored after.)