### PR TITLE
Update Brazilian Portuguese translations

### DIFF
--- a/po/openweather.pot
+++ b/po/openweather.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-openweatherrefined\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-18 09:26-0500\n"
+"POT-Creation-Date: 2024-06-25 06:19-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,20 +17,39 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/weathericons.js:292 src/weathericons.js:294 src/weathericons.js:296
-msgid "Not available"
+#: src/openweathermap.js:88
+msgid "OpenWeather Refined Too Many Requests"
 msgstr ""
 
-#: src/locs.js:101 src/locs.js:185 src/preferences/locationsPage.js:329
-#: src/preferences/locationsPage.js:393
-msgid "My Location"
+#: src/openweathermap.js:89
+#, javascript-format
+msgid ""
+"Provider %s has too many users. Try switching weather providers in settings."
+msgstr ""
+
+#: src/openweathermap.js:137 src/preferences/aboutPage.js:88
+#: src/preferences/aboutPage.js:89
+msgid "Unknown"
+msgstr ""
+
+#: src/openweathermap.js:173
+msgid ", "
+msgstr ""
+
+#: src/openweathermap.js:278
+msgid "Tomorrow"
+msgstr ""
+
+#: src/weathericons.js:377 src/weathericons.js:379 src/weathericons.js:381
+#: src/weathericons.js:383
+msgid "Not available"
 msgstr ""
 
 #: src/extension.js:248
 msgid "Failed to initialize."
 msgstr ""
 
-#: src/extension.js:375
+#: src/extension.js:382
 #, javascript-format
 msgid ""
 "%s does not work without an api-key.\n"
@@ -39,465 +58,285 @@ msgid ""
 "preferences dialog."
 msgstr ""
 
-#: src/extension.js:432
+#: src/extension.js:439
 msgid "OpenWeather Refined: Imported settings from old extension."
 msgstr ""
 
-#: src/extension.js:745 src/extension.js:758
+#: src/extension.js:756 src/extension.js:769
 #, javascript-format
 msgid "Can not connect to %s"
 msgstr ""
 
-#: src/extension.js:1044 src/preferences/locationsPage.js:39
+#: src/extension.js:1043 src/preferences/locationsPage.js:39
 #: src/preferences/locationsPage.js:59
 msgid "Locations"
 msgstr ""
 
-#: src/extension.js:1048
+#: src/extension.js:1047
 msgid "Reload Weather Information"
 msgstr ""
 
-#: src/extension.js:1066
+#: src/extension.js:1065
 msgid "See Online"
 msgstr ""
 
-#: src/extension.js:1071
+#: src/extension.js:1070
 msgid "Weather Settings"
 msgstr ""
 
-#: src/extension.js:1099
+#: src/extension.js:1098
 msgid "Manual refreshes less than 2 minutes apart are ignored!"
 msgstr ""
 
-#: src/extension.js:1141
+#: src/extension.js:1140
 #, javascript-format
 msgid "Cannot open %s"
 msgstr ""
 
-#: src/extension.js:1231 src/preferences/generalPage.js:194
+#: src/extension.js:1227 src/preferences/generalPage.js:214
 msgid "°C"
 msgstr ""
 
-#: src/extension.js:1234 src/preferences/generalPage.js:195
+#: src/extension.js:1230 src/preferences/generalPage.js:215
 msgid "°F"
 msgstr ""
 
-#: src/extension.js:1236 src/preferences/generalPage.js:196
+#: src/extension.js:1232 src/preferences/generalPage.js:216
 msgid "K"
 msgstr ""
 
-#: src/extension.js:1238 src/preferences/generalPage.js:197
+#: src/extension.js:1234 src/preferences/generalPage.js:217
 msgid "°Ra"
 msgstr ""
 
-#: src/extension.js:1240 src/preferences/generalPage.js:198
+#: src/extension.js:1236 src/preferences/generalPage.js:218
 msgid "°Ré"
 msgstr ""
 
-#: src/extension.js:1242 src/preferences/generalPage.js:199
+#: src/extension.js:1238 src/preferences/generalPage.js:219
 msgid "°Rø"
 msgstr ""
 
-#: src/extension.js:1244 src/preferences/generalPage.js:200
+#: src/extension.js:1240 src/preferences/generalPage.js:220
 msgid "°De"
 msgstr ""
 
-#: src/extension.js:1246 src/preferences/generalPage.js:201
+#: src/extension.js:1242 src/preferences/generalPage.js:221
 msgid "°N"
 msgstr ""
 
-#: src/extension.js:1282
+#: src/extension.js:1250
 msgid "Calm"
 msgstr ""
 
-#: src/extension.js:1283
+#: src/extension.js:1251
 msgid "Light air"
 msgstr ""
 
-#: src/extension.js:1285
+#: src/extension.js:1253
 msgid "Light breeze"
 msgstr ""
 
-#: src/extension.js:1287
+#: src/extension.js:1255
 msgid "Gentle breeze"
 msgstr ""
 
-#: src/extension.js:1289
+#: src/extension.js:1257
 msgid "Moderate breeze"
 msgstr ""
 
-#: src/extension.js:1291
+#: src/extension.js:1259
 msgid "Fresh breeze"
 msgstr ""
 
-#: src/extension.js:1293
+#: src/extension.js:1261
 msgid "Strong breeze"
 msgstr ""
 
-#: src/extension.js:1295
+#: src/extension.js:1263
 msgid "Moderate gale"
 msgstr ""
 
-#: src/extension.js:1297
+#: src/extension.js:1265
 msgid "Fresh gale"
 msgstr ""
 
-#: src/extension.js:1299
+#: src/extension.js:1267
 msgid "Strong gale"
 msgstr ""
 
-#: src/extension.js:1300
+#: src/extension.js:1268
 msgid "Storm"
 msgstr ""
 
-#: src/extension.js:1302
+#: src/extension.js:1270
 msgid "Violent storm"
 msgstr ""
 
-#: src/extension.js:1303
+#: src/extension.js:1271
 msgid "Hurricane"
 msgstr ""
 
-#: src/extension.js:1308
+#: src/extension.js:1276
 msgid "Sunday"
 msgstr ""
 
-#: src/extension.js:1309
+#: src/extension.js:1277
 msgid "Monday"
 msgstr ""
 
-#: src/extension.js:1310
+#: src/extension.js:1278
 msgid "Tuesday"
 msgstr ""
 
-#: src/extension.js:1311
+#: src/extension.js:1279
 msgid "Wednesday"
 msgstr ""
 
-#: src/extension.js:1312
+#: src/extension.js:1280
 msgid "Thursday"
 msgstr ""
 
-#: src/extension.js:1313
+#: src/extension.js:1281
 msgid "Friday"
 msgstr ""
 
-#: src/extension.js:1314
+#: src/extension.js:1282
 msgid "Saturday"
 msgstr ""
 
-#: src/extension.js:1331
+#: src/extension.js:1299
 msgid "N"
 msgstr ""
 
-#: src/extension.js:1332
+#: src/extension.js:1300
 msgid "NE"
 msgstr ""
 
-#: src/extension.js:1333
+#: src/extension.js:1301
 msgid "E"
 msgstr ""
 
-#: src/extension.js:1334
+#: src/extension.js:1302
 msgid "SE"
 msgstr ""
 
-#: src/extension.js:1335
+#: src/extension.js:1303
 msgid "S"
 msgstr ""
 
-#: src/extension.js:1336
+#: src/extension.js:1304
 msgid "SW"
 msgstr ""
 
-#: src/extension.js:1337
+#: src/extension.js:1305
 msgid "W"
 msgstr ""
 
-#: src/extension.js:1338
+#: src/extension.js:1306
 msgid "NW"
 msgstr ""
 
-#: src/extension.js:1427 src/preferences/generalPage.js:227
+#: src/extension.js:1395 src/preferences/generalPage.js:247
 msgid "inHg"
 msgstr ""
 
-#: src/extension.js:1432 src/preferences/generalPage.js:228
+#: src/extension.js:1400 src/preferences/generalPage.js:248
 msgid "bar"
 msgstr ""
 
-#: src/extension.js:1437 src/preferences/generalPage.js:229
+#: src/extension.js:1405 src/preferences/generalPage.js:249
 msgid "Pa"
 msgstr ""
 
-#: src/extension.js:1442 src/preferences/generalPage.js:230
+#: src/extension.js:1410 src/preferences/generalPage.js:250
 msgid "kPa"
 msgstr ""
 
-#: src/extension.js:1447 src/preferences/generalPage.js:231
+#: src/extension.js:1415 src/preferences/generalPage.js:251
 msgid "atm"
 msgstr ""
 
-#: src/extension.js:1452 src/preferences/generalPage.js:232
+#: src/extension.js:1420 src/preferences/generalPage.js:252
 msgid "at"
 msgstr ""
 
-#: src/extension.js:1457 src/preferences/generalPage.js:233
+#: src/extension.js:1425 src/preferences/generalPage.js:253
 msgid "Torr"
 msgstr ""
 
-#: src/extension.js:1462 src/preferences/generalPage.js:234
+#: src/extension.js:1430 src/preferences/generalPage.js:254
 msgid "psi"
 msgstr ""
 
-#: src/extension.js:1467 src/preferences/generalPage.js:235
+#: src/extension.js:1435 src/preferences/generalPage.js:255
 msgid "mmHg"
 msgstr ""
 
-#: src/extension.js:1471 src/preferences/generalPage.js:236
+#: src/extension.js:1439 src/preferences/generalPage.js:256
 msgid "mbar"
 msgstr ""
 
-#: src/extension.js:1537 src/preferences/generalPage.js:214
+#: src/extension.js:1507 src/preferences/generalPage.js:234
 msgid "m/s"
 msgstr ""
 
-#: src/extension.js:1542 src/preferences/generalPage.js:213
+#: src/extension.js:1512 src/preferences/generalPage.js:233
 msgid "mph"
 msgstr ""
 
-#: src/extension.js:1547 src/preferences/generalPage.js:212
+#: src/extension.js:1517 src/preferences/generalPage.js:232
 msgid "km/h"
 msgstr ""
 
-#: src/extension.js:1556 src/preferences/generalPage.js:215
+#: src/extension.js:1526 src/preferences/generalPage.js:235
 msgid "kn"
 msgstr ""
 
-#: src/extension.js:1561 src/preferences/generalPage.js:216
+#: src/extension.js:1531 src/preferences/generalPage.js:236
 msgid "ft/s"
 msgstr ""
 
-#: src/extension.js:1628 src/extension.js:1678
+#: src/extension.js:1601 src/extension.js:1651
 msgid "Loading ..."
 msgstr ""
 
-#: src/extension.js:1682
+#: src/extension.js:1655
 msgid "Please wait"
 msgstr ""
 
-#: src/extension.js:1739
+#: src/extension.js:1712
 msgid "Feels Like:"
 msgstr ""
 
-#: src/extension.js:1740
+#: src/extension.js:1713
 msgid "Humidity:"
 msgstr ""
 
-#: src/extension.js:1741
+#: src/extension.js:1714
 msgid "Pressure:"
 msgstr ""
 
-#: src/extension.js:1742
+#: src/extension.js:1715
 msgid "Wind:"
 msgstr ""
 
-#: src/extension.js:1743
+#: src/extension.js:1716
 msgid "Gusts"
 msgstr ""
 
-#: src/extension.js:1925
+#: src/extension.js:1898
 msgid "Tomorrow's Forecast"
 msgstr ""
 
-#: src/extension.js:1926
+#: src/extension.js:1899
 #, javascript-format
 msgid "%s Day Forecast"
 msgstr ""
 
-#: src/openweathermap.js:139
-msgid ", "
-msgstr ""
-
-#: src/openweathermap.js:238
-msgid "Tomorrow"
-msgstr ""
-
-#: src/preferences/generalPage.js:28
-#, javascript-format
-msgid "%s Multilingual Support"
-msgstr ""
-
-#: src/preferences/generalPage.js:33
-#, javascript-format
-msgid "Use a personal API key for %s"
-msgstr ""
-
-#: src/preferences/generalPage.js:38
-#, javascript-format
-msgid "Enable this if you have your own API key from %s and enter it below."
-msgstr ""
-
-#: src/preferences/generalPage.js:51
-msgid "Settings"
-msgstr ""
-
-#: src/preferences/generalPage.js:60
-msgid "General"
-msgstr ""
-
-#: src/preferences/generalPage.js:78
-msgid "Current Weather Refresh"
-msgstr ""
-
-#: src/preferences/generalPage.js:79
-msgid "Current weather refresh interval in minutes"
-msgstr ""
-
-#: src/preferences/generalPage.js:101
-msgid "Weather Forecast Refresh"
-msgstr ""
-
-#: src/preferences/generalPage.js:102
-msgid "Forecast refresh interval in minutes if enabled"
-msgstr ""
-
-#: src/preferences/generalPage.js:122
-msgid "My Location Refresh"
-msgstr ""
-
-#: src/preferences/generalPage.js:123
-msgid "My location refresh interval in minutes"
-msgstr ""
-
-#: src/preferences/generalPage.js:134
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:122
-msgid "Disable Forecast"
-msgstr ""
-
-#: src/preferences/generalPage.js:135
-msgid "Disables all fetching and processing of forecast data"
-msgstr ""
-
-#: src/preferences/generalPage.js:146
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:110
-msgid "System Icons"
-msgstr ""
-
-#: src/preferences/generalPage.js:147
-#, javascript-format
-msgid "Disable to use packaged %s weather icons"
-msgstr ""
-
-#: src/preferences/generalPage.js:149
-msgid ""
-"If you have issues with your system icons displaying correctly disable this "
-"to fix it"
-msgstr ""
-
-#: src/preferences/generalPage.js:170
-msgid "First Boot Delay"
-msgstr ""
-
-#: src/preferences/generalPage.js:171
-msgid "Seconds to delay popup initialization and data fetching"
-msgstr ""
-
-#: src/preferences/generalPage.js:173
-msgid ""
-"This setting only applies to the first time the extension is loaded. (first "
-"log in / restarting gnome shell)"
-msgstr ""
-
-#: src/preferences/generalPage.js:189
-msgid "Units"
-msgstr ""
-
-#: src/preferences/generalPage.js:205
-msgid "Temperature"
-msgstr ""
-
-#: src/preferences/generalPage.js:217
-msgid "Beaufort"
-msgstr ""
-
-#: src/preferences/generalPage.js:219
-msgid "Wind Speed"
-msgstr ""
-
-#: src/preferences/generalPage.js:238
-msgid "Pressure"
-msgstr ""
-
-#: src/preferences/generalPage.js:245
-msgid "24-hour"
-msgstr ""
-
-#: src/preferences/generalPage.js:246
-msgid "AM / PM"
-msgstr ""
-
-#: src/preferences/generalPage.js:247
-msgid "System"
-msgstr ""
-
-#: src/preferences/generalPage.js:249
-msgid "Time Format"
-msgstr ""
-
-#: src/preferences/generalPage.js:260
-msgid "Simplify Degrees"
-msgstr ""
-
-#: src/preferences/generalPage.js:261
-msgid "Show \"°\" instead of \"°C,\" \"°F,\" etc."
-msgstr ""
-
-#: src/preferences/generalPage.js:262
-msgid "Enable this to cut off the \"C,\" \"F,\" etc. from degrees labels."
-msgstr ""
-
-#: src/preferences/generalPage.js:276 src/preferences/locationsPage.js:67
-msgid "Provider"
-msgstr ""
-
-#: src/preferences/generalPage.js:287
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:67
-msgid "Weather Provider"
-msgstr ""
-
-#: src/preferences/generalPage.js:288
-msgid "Provider used for weather and forecasts"
-msgstr ""
-
-#: src/preferences/generalPage.js:301
-msgid "Using provider translations applies to weather conditions only"
-msgstr ""
-
-#: src/preferences/generalPage.js:304
-msgid ""
-"Enable this to use provider multilingual support if there's no built-in "
-"translations for your language yet."
-msgstr ""
-
-#: src/preferences/generalPage.js:317
-msgid "Use Custom API Key"
-msgstr ""
-
-#: src/preferences/generalPage.js:333
-msgid "Personal API Key"
-msgstr ""
-
-#: src/preferences/generalPage.js:369 src/preferences/generalPage.js:375
-msgid "Reset"
-msgstr ""
-
-#: src/preferences/generalPage.js:379
-msgid "Restore Defaults"
-msgstr ""
-
-#: src/preferences/generalPage.js:381
-msgid "Restore all settings to the defaults."
+#: src/locs.js:102 src/locs.js:186 src/preferences/locationsPage.js:331
+#: src/preferences/locationsPage.js:395
+msgid "My Location"
 msgstr ""
 
 #: src/preferences/layoutPage.js:31
@@ -582,7 +421,7 @@ msgid "Wind Direction Arrows"
 msgstr ""
 
 #: src/preferences/layoutPage.js:176
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:102
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:103
 msgid "Translate Conditions"
 msgstr ""
 
@@ -592,17 +431,17 @@ msgid "0"
 msgstr ""
 
 #: src/preferences/layoutPage.js:185 src/preferences/layoutPage.js:199
-#: src/preferences/layoutPage.js:213 src/preferences/layoutPage.js:302
+#: src/preferences/layoutPage.js:213
 msgid "1"
 msgstr ""
 
 #: src/preferences/layoutPage.js:186 src/preferences/layoutPage.js:200
-#: src/preferences/layoutPage.js:214 src/preferences/layoutPage.js:303
+#: src/preferences/layoutPage.js:214
 msgid "2"
 msgstr ""
 
 #: src/preferences/layoutPage.js:187 src/preferences/layoutPage.js:201
-#: src/preferences/layoutPage.js:215 src/preferences/layoutPage.js:304
+#: src/preferences/layoutPage.js:215
 msgid "3"
 msgstr ""
 
@@ -624,7 +463,6 @@ msgid "Follow Temp."
 msgstr ""
 
 #: src/preferences/layoutPage.js:202 src/preferences/layoutPage.js:216
-#: src/preferences/layoutPage.js:305
 msgid "4"
 msgstr ""
 
@@ -644,52 +482,210 @@ msgstr ""
 msgid "Maximum length of the location text. A setting of '0' is unlimited"
 msgstr ""
 
-#: src/preferences/layoutPage.js:249
-msgid "Off"
+#: src/preferences/layoutPage.js:243
+msgid "Maximum length to cut off the location text at. \"0\" is unlimited."
 msgstr ""
 
 #: src/preferences/layoutPage.js:250
-msgid "White Text"
+msgid "Off"
 msgstr ""
 
 #: src/preferences/layoutPage.js:251
+msgid "White Text"
+msgstr ""
+
+#: src/preferences/layoutPage.js:252
 msgid "Black Text"
 msgstr ""
 
-#: src/preferences/layoutPage.js:253
+#: src/preferences/layoutPage.js:254
 msgid "High Contrast"
 msgstr ""
 
-#: src/preferences/layoutPage.js:254
+#: src/preferences/layoutPage.js:255
+msgid ""
+"Override GNOME shell text colors in the pop-up with hard-coded ones that may "
+"be easier to read. This may not be very effective depending on your shell "
+"theme."
+msgstr ""
+
+#: src/preferences/layoutPage.js:256
 msgid "Enable to override GNOME shell colors"
 msgstr ""
 
-#: src/preferences/layoutPage.js:273
+#: src/preferences/layoutPage.js:275
 msgid "Forecast"
 msgstr ""
 
-#: src/preferences/layoutPage.js:283
+#: src/preferences/layoutPage.js:285
 msgid "Center Today's Forecast"
 msgstr ""
 
-#: src/preferences/layoutPage.js:294
+#: src/preferences/layoutPage.js:286
+msgid "Center today's forecast instead of left-aligning it."
+msgstr ""
+
+#: src/preferences/layoutPage.js:297
 msgid "Conditions In Forecast"
 msgstr ""
 
-#: src/preferences/layoutPage.js:301
-msgid "Today Only"
+#: src/preferences/layoutPage.js:298
+msgid "Show the condition text (e.g. \"Cloudy\") in the forecast."
 msgstr ""
 
-#: src/preferences/layoutPage.js:306
-msgid "5"
-msgstr ""
-
-#: src/preferences/layoutPage.js:308
+#: src/preferences/layoutPage.js:318
 msgid "Total Days In Forecast"
 msgstr ""
 
-#: src/preferences/layoutPage.js:319
+#: src/preferences/layoutPage.js:320
+msgid ""
+"Number of days to show in forecast where a setting of \"0\" is only today"
+msgstr ""
+
+#: src/preferences/layoutPage.js:322
+#, javascript-format
+msgid ""
+"Number of days to show in forecast. \"0\" means only show today.\n"
+"Different providers support different amounts of days.\n"
+"Currently \"%s\" supports the furthest forecast of %s days."
+msgstr ""
+
+#: src/preferences/layoutPage.js:333
 msgid "Keep Forecast Expanded"
+msgstr ""
+
+#: src/preferences/layoutPage.js:334
+msgid "Automatically open the forecast when the pop-up is opened."
+msgstr ""
+
+#: src/preferences/locationsPage.js:55
+msgid "Add"
+msgstr ""
+
+#: src/preferences/locationsPage.js:67 src/preferences/generalPage.js:35
+#: src/preferences/generalPage.js:42 src/preferences/generalPage.js:315
+msgid "Provider"
+msgstr ""
+
+#: src/preferences/locationsPage.js:75
+msgid "My Loc. Provider"
+msgstr ""
+
+#: src/preferences/locationsPage.js:76
+msgid "Provider for getting My Location"
+msgstr ""
+
+#: src/preferences/locationsPage.js:85
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:72
+msgid "Geolocation Provider"
+msgstr ""
+
+#: src/preferences/locationsPage.js:86
+msgid "Provider used for location search"
+msgstr ""
+
+#: src/preferences/locationsPage.js:99
+msgid "Personal MapQuest Key"
+msgstr ""
+
+#: src/preferences/locationsPage.js:100
+msgid "Personal API Key from developer.mapquest.com"
+msgstr ""
+
+#: src/preferences/locationsPage.js:264
+#, javascript-format
+msgid "Location changed to: %s"
+msgstr ""
+
+#: src/preferences/locationsPage.js:294
+msgid "Add New Location"
+msgstr ""
+
+#: src/preferences/locationsPage.js:315
+msgid "Search by Location or Coordinates"
+msgstr ""
+
+#: src/preferences/locationsPage.js:321
+msgid "e.g. London, England or 51.5074456,-0.1277653"
+msgstr ""
+
+#: src/preferences/locationsPage.js:323 src/preferences/locationsPage.js:451
+#: src/preferences/locationsPage.js:468
+msgid "Clear entry"
+msgstr ""
+
+#: src/preferences/locationsPage.js:340
+msgid "Search"
+msgstr ""
+
+#: src/preferences/locationsPage.js:366
+msgid "We need something to search for!"
+msgstr ""
+
+#: src/preferences/locationsPage.js:395
+#: src/preferences/searchResultsWindow.js:273
+#, javascript-format
+msgid "%s has been added"
+msgstr ""
+
+#: src/preferences/locationsPage.js:411
+#, javascript-format
+msgid "Edit %s"
+msgstr ""
+
+#: src/preferences/locationsPage.js:433
+msgid "Edit Name"
+msgstr ""
+
+#: src/preferences/locationsPage.js:459
+msgid "Edit Coordinates"
+msgstr ""
+
+#: src/preferences/locationsPage.js:475
+msgid ""
+"If you meant to search up a new location by name, <b>add</b> a location "
+"instead."
+msgstr ""
+
+#: src/preferences/locationsPage.js:484
+msgid "Save"
+msgstr ""
+
+#: src/preferences/locationsPage.js:519
+msgid "Coordinates field cannot be empty."
+msgstr ""
+
+#: src/preferences/locationsPage.js:527
+#, javascript-format
+msgid "Coordinates field must be in the format of '%s' or the text '%s'."
+msgstr ""
+
+#: src/preferences/locationsPage.js:535
+#, javascript-format
+msgid "Name field can only be empty if coordinates are '%s'."
+msgstr ""
+
+#: src/preferences/locationsPage.js:564
+#, javascript-format
+msgid "%s has been updated"
+msgstr ""
+
+#: src/preferences/locationsPage.js:595
+#, javascript-format
+msgid "Are you sure you want to delete \"%s\"?"
+msgstr ""
+
+#: src/preferences/locationsPage.js:603
+msgid "Delete"
+msgstr ""
+
+#: src/preferences/locationsPage.js:607
+msgid "Cancel"
+msgstr ""
+
+#: src/preferences/locationsPage.js:636
+#, javascript-format
+msgid "%s has been deleted"
 msgstr ""
 
 #: src/preferences/searchResultsWindow.js:36
@@ -724,12 +720,6 @@ msgstr ""
 msgid "Results for \"%s\""
 msgstr ""
 
-#: src/preferences/searchResultsWindow.js:273
-#: src/preferences/locationsPage.js:393
-#, javascript-format
-msgid "%s has been added"
-msgstr ""
-
 #: src/preferences/searchResultsWindow.js:284
 msgid "API Error"
 msgstr ""
@@ -748,370 +738,463 @@ msgstr ""
 msgid "No results found when searching for \"%s\"."
 msgstr ""
 
-#: src/preferences/aboutPage.js:36
+#: src/preferences/aboutPage.js:45
 msgid "About"
 msgstr ""
 
-#: src/preferences/aboutPage.js:64
+#: src/preferences/aboutPage.js:73
 msgid ""
 "Display weather information for any location on Earth in the GNOME Shell."
 msgstr ""
 
-#: src/preferences/aboutPage.js:79 src/preferences/aboutPage.js:80
-msgid "Unknown"
-msgstr ""
-
-#: src/preferences/aboutPage.js:84
+#: src/preferences/aboutPage.js:93
 msgid "OpenWeather Refined Version"
 msgstr ""
 
-#: src/preferences/aboutPage.js:96
+#: src/preferences/aboutPage.js:105
 msgid "Git Version"
 msgstr ""
 
-#: src/preferences/aboutPage.js:107
+#: src/preferences/aboutPage.js:116
 msgid "GNOME Version"
 msgstr ""
 
-#: src/preferences/aboutPage.js:117
+#: src/preferences/aboutPage.js:126
 msgid "Copy Settings JSON"
 msgstr ""
 
-#: src/preferences/aboutPage.js:120
+#: src/preferences/aboutPage.js:129
 msgid "Copy"
 msgstr ""
 
-#: src/preferences/aboutPage.js:167
+#: src/preferences/aboutPage.js:134
+msgid "Paste"
+msgstr ""
+
+#: src/preferences/aboutPage.js:203
 msgid "Copied settings JSON to clipboard."
 msgstr ""
 
-#: src/preferences/aboutPage.js:188
+#: src/preferences/aboutPage.js:219
+msgid "Clipboard contains no text."
+msgstr ""
+
+#: src/preferences/aboutPage.js:226
+msgid "Clipboard didn't contain valid JSON."
+msgstr ""
+
+#: src/preferences/aboutPage.js:269
 #, javascript-format
 msgid "Maintained by: %s"
 msgstr ""
 
-#: src/preferences/aboutPage.js:194
+#: src/preferences/aboutPage.js:275
 #, javascript-format
 msgid "Contribute or translate the project on %s."
 msgstr ""
 
-#: src/preferences/aboutPage.js:200
+#: src/preferences/aboutPage.js:281
 #, javascript-format
 msgid "This is a fork of %s's extension."
 msgstr ""
 
-#: src/preferences/aboutPage.js:222
+#: src/preferences/aboutPage.js:306
 #, javascript-format
 msgid "Weather data provided by: %s"
 msgstr ""
 
-#: src/preferences/aboutPage.js:236
+#: src/preferences/aboutPage.js:321
 msgid "This program comes with ABSOLUTELY NO WARRANTY."
 msgstr ""
 
-#: src/preferences/aboutPage.js:238
+#: src/preferences/aboutPage.js:323
 msgid "See the"
 msgstr ""
 
-#: src/preferences/aboutPage.js:240
+#: src/preferences/aboutPage.js:325
 msgid "GNU General Public License, version 2 or later"
 msgstr ""
 
-#: src/preferences/aboutPage.js:242
+#: src/preferences/aboutPage.js:327
 msgid "for details."
 msgstr ""
 
-#: src/preferences/locationsPage.js:55
-msgid "Add"
+#: src/preferences/generalPage.js:29
+msgid "Provider Multilingual Support"
 msgstr ""
 
-#: src/preferences/locationsPage.js:75
-msgid "My Loc. Provider"
-msgstr ""
-
-#: src/preferences/locationsPage.js:76
-msgid "Provider for getting My Location"
-msgstr ""
-
-#: src/preferences/locationsPage.js:85
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:71
-msgid "Geolocation Provider"
-msgstr ""
-
-#: src/preferences/locationsPage.js:86
-msgid "Provider used for location search"
-msgstr ""
-
-#: src/preferences/locationsPage.js:99
-msgid "Personal MapQuest Key"
-msgstr ""
-
-#: src/preferences/locationsPage.js:100
-msgid "Personal API Key from developer.mapquest.com"
-msgstr ""
-
-#: src/preferences/locationsPage.js:262
+#: src/preferences/generalPage.js:35
 #, javascript-format
-msgid "Location changed to: %s"
+msgid "Use a personal API key for %s"
 msgstr ""
 
-#: src/preferences/locationsPage.js:292
-msgid "Add New Location"
-msgstr ""
-
-#: src/preferences/locationsPage.js:313
-msgid "Search by Location or Coordinates"
-msgstr ""
-
-#: src/preferences/locationsPage.js:319
-msgid "e.g. London, England or 51.5074456,-0.1277653"
-msgstr ""
-
-#: src/preferences/locationsPage.js:321 src/preferences/locationsPage.js:449
-#: src/preferences/locationsPage.js:466
-msgid "Clear entry"
-msgstr ""
-
-#: src/preferences/locationsPage.js:338
-msgid "Search"
-msgstr ""
-
-#: src/preferences/locationsPage.js:364
-msgid "We need something to search for!"
-msgstr ""
-
-#: src/preferences/locationsPage.js:409
+#: src/preferences/generalPage.js:41
 #, javascript-format
-msgid "Edit %s"
+msgid "Enable this if you have your own API key from %s and enter it below."
 msgstr ""
 
-#: src/preferences/locationsPage.js:431
-msgid "Edit Name"
+#: src/preferences/generalPage.js:71
+msgid "Settings"
 msgstr ""
 
-#: src/preferences/locationsPage.js:457
-msgid "Edit Coordinates"
+#: src/preferences/generalPage.js:80
+msgid "General"
 msgstr ""
 
-#: src/preferences/locationsPage.js:473
+#: src/preferences/generalPage.js:98
+msgid "Current Weather Refresh"
+msgstr ""
+
+#: src/preferences/generalPage.js:99
+msgid "Current weather refresh interval in minutes"
+msgstr ""
+
+#: src/preferences/generalPage.js:121
+msgid "Weather Forecast Refresh"
+msgstr ""
+
+#: src/preferences/generalPage.js:122
+msgid "Forecast refresh interval in minutes if enabled"
+msgstr ""
+
+#: src/preferences/generalPage.js:142
+msgid "My Location Refresh"
+msgstr ""
+
+#: src/preferences/generalPage.js:143
+msgid "My location refresh interval in minutes"
+msgstr ""
+
+#: src/preferences/generalPage.js:154
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:123
+msgid "Disable Forecast"
+msgstr ""
+
+#: src/preferences/generalPage.js:155
+msgid "Disables all fetching and processing of forecast data"
+msgstr ""
+
+#: src/preferences/generalPage.js:166
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:111
+msgid "System Icons"
+msgstr ""
+
+#: src/preferences/generalPage.js:167
+#, javascript-format
+msgid "Disable to use packaged %s weather icons"
+msgstr ""
+
+#: src/preferences/generalPage.js:169
 msgid ""
-"If you meant to search up a new location by name, <b>add</b> a location "
-"instead."
+"If you have issues with your system icons displaying correctly disable this "
+"to fix it"
 msgstr ""
 
-#: src/preferences/locationsPage.js:482
-msgid "Save"
+#: src/preferences/generalPage.js:190
+msgid "First Boot Delay"
 msgstr ""
 
-#: src/preferences/locationsPage.js:517
-msgid "Coordinates field cannot be empty."
+#: src/preferences/generalPage.js:191
+msgid "Seconds to delay popup initialization and data fetching"
 msgstr ""
 
-#: src/preferences/locationsPage.js:525
+#: src/preferences/generalPage.js:193
+msgid ""
+"This setting only applies to the first time the extension is loaded. (first "
+"log in / restarting gnome shell)"
+msgstr ""
+
+#: src/preferences/generalPage.js:209
+msgid "Units"
+msgstr ""
+
+#: src/preferences/generalPage.js:225
+msgid "Temperature"
+msgstr ""
+
+#: src/preferences/generalPage.js:237
+msgid "Beaufort"
+msgstr ""
+
+#: src/preferences/generalPage.js:239
+msgid "Wind Speed"
+msgstr ""
+
+#: src/preferences/generalPage.js:258
+msgid "Pressure"
+msgstr ""
+
+#: src/preferences/generalPage.js:265
+msgid "24-hour"
+msgstr ""
+
+#: src/preferences/generalPage.js:266
+msgid "AM / PM"
+msgstr ""
+
+#: src/preferences/generalPage.js:267
+msgid "System"
+msgstr ""
+
+#: src/preferences/generalPage.js:269
+msgid "Time Format"
+msgstr ""
+
+#: src/preferences/generalPage.js:280
+msgid "Simplify Degrees"
+msgstr ""
+
+#: src/preferences/generalPage.js:281
+msgid "Show \"°\" instead of \"°C,\" \"°F,\" etc."
+msgstr ""
+
+#: src/preferences/generalPage.js:282
+msgid "Enable this to cut off the \"C,\" \"F,\" etc. from degrees labels."
+msgstr ""
+
+#: src/preferences/generalPage.js:295
+msgid "Notifications"
+msgstr ""
+
+#: src/preferences/generalPage.js:303
+msgid "Precipitation Starting"
+msgstr ""
+
+#: src/preferences/generalPage.js:304 src/preferences/generalPage.js:305
+msgid "Get notified when precipitation starts (e.g. rain or snow)."
+msgstr ""
+
+#: src/preferences/generalPage.js:322 src/preferences/generalPage.js:329
+#: src/preferences/generalPage.js:330
+msgid "Adaptive"
+msgstr ""
+
+#: src/preferences/generalPage.js:328
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:68
+msgid "Weather Provider"
+msgstr ""
+
+#: src/preferences/generalPage.js:329
 #, javascript-format
-msgid "Coordinates field must be in the format of '%s' or the text '%s'."
+msgid ""
+"Provider used for weather and forecasts; choose \"%s\" if you don't care."
 msgstr ""
 
-#: src/preferences/locationsPage.js:533
+#: src/preferences/generalPage.js:330
 #, javascript-format
-msgid "Name field can only be empty if coordinates are '%s'."
+msgid "Choose '%s' if you don't care, otherwise choose a specific provider."
 msgstr ""
 
-#: src/preferences/locationsPage.js:562
-#, javascript-format
-msgid "%s has been updated"
+#: src/preferences/generalPage.js:343
+msgid "Using provider translations applies to weather conditions only"
 msgstr ""
 
-#: src/preferences/locationsPage.js:593
-#, javascript-format
-msgid "Are you sure you want to delete \"%s\"?"
+#: src/preferences/generalPage.js:346
+msgid ""
+"Enable this to use provider multilingual support if there's no built-in "
+"translations for your language yet."
 msgstr ""
 
-#: src/preferences/locationsPage.js:601
-msgid "Delete"
+#: src/preferences/generalPage.js:361
+msgid "Use Custom API Key"
 msgstr ""
 
-#: src/preferences/locationsPage.js:605
-msgid "Cancel"
+#: src/preferences/generalPage.js:377
+msgid "Personal API Key"
 msgstr ""
 
-#: src/preferences/locationsPage.js:634
-#, javascript-format
-msgid "%s has been deleted"
+#: src/preferences/generalPage.js:394 src/preferences/generalPage.js:400
+msgid "Reset"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:75
+#: src/preferences/generalPage.js:404
+msgid "Restore Defaults"
+msgstr ""
+
+#: src/preferences/generalPage.js:406
+msgid "Restore all settings to the defaults."
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:76
 msgid "Temperature Unit"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:79
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:80
 msgid "Pressure Unit"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:84
 msgid "Wind Speed Units"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:84
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:85
 msgid ""
 "Choose the units used for wind speed. Allowed values are 'kph', 'mph', 'm/"
 "s', 'knots', 'ft/s' or 'Beaufort'."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:89
 msgid "Wind Direction by Arrows"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:89
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:90
 msgid "True to display wind direction through arrows rather than letters."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:94
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:95
 msgid "DEPRECATED, City to be displayed"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:98
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:99
 msgid "Index of the city to display by default."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:106
-msgid "OpenWeatherMap Multilingual Support (weather descriptions only)"
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:107
+msgid "Provider multilingual Support (weather descriptions only)"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:114
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:115
 msgid "True to show temperature in the panel"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:118
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:119
 msgid "True to show conditions in the panel."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:126
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:127
 msgid "Conditions in Forecast"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:130
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:134
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:131
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:135
 msgid "Position in Panel"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:138
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:139
 msgid "Horizontal position of menu-box."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:142
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:143
 msgid "Refresh interval (actual weather)"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:146
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:147
 msgid "Maximum length of the location text"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:150
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:151
 msgid "Refresh interval (forecast)"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:154
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:155
 msgid "Center forecastbox."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:158
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:159
 msgid "Always keep forecast expanded"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:162
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:163
 msgid "Number of days in forecast"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:166
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:167
 msgid "Maximum number of digits after the decimal point for temperature"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:170
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:171
 msgid "Maximum number of digits after the decimal point for pressure"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:174
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:175
 msgid "Maximum number of digits after the decimal point for wind speed"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:178
-msgid "Your personal API key from openweathermap.org"
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:180
+msgid "DEPRECATED. Your personal API key from openweathermap.org"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:182
-msgid "Your personal API key from WeatherAPI.com"
-msgstr ""
-
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:186
-msgid "Use the extensions default API key from openweathermap.org"
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:185
+msgid "DEPRECATED. Your personal API key from WeatherAPI.com"
 msgstr ""
 
 #: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:190
-msgid "Use the extensions default API key from WeatherAPI.com"
+msgid "DEPRECATED. Use the extensions default API key from openweathermap.org"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:194
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:195
+msgid "DEPRECATED. Use the extensions default API key from WeatherAPI.com"
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:199
 msgid "Your personal AppKey from developer.mapquest.com"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:198
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:203
 msgid ""
 "Time format for hours. Possible values are '24hr' for 24-hour clock, '12hr' "
 "for AM/PM, and 'system' to follow the GNOME setting."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:202
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:207
 msgid "Seconds to delay popup initialization and data fetch on the first load"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:206
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:211
 msgid "Default width for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:210
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:215
 msgid "Default height for the preferences window"
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:214
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:219
 msgid ""
 "High contrast style to use, possible values are 'none', 'white', or 'black'."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:218
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:223
 msgid "True to show the sunset/sunrise in the panel."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:222
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:227
 msgid ""
 "True to show the sunset/sunrise in the panel before the temperature/"
 "conditions if enabled."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:226
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:231
 msgid "False if this extension has never been initialized before."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:230
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:235
 msgid "How often, in minutes, to re-fetch My Location if selected."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:234
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:239
 msgid "True to cut off the \"F\" or \"C\" after the degree symbol."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:238
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:243
 msgid "Freezes the settings changed listener; user should not change this."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:243
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:248
 msgid "List of locations."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:247
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:252
 msgid "Provider to use for \"My Location.\""
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:251
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:256
 msgid "Empty or the last initialization error message."
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:260
+msgid "Custom keys for weather providers."
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:264
+msgid "Get a notification when precipitation starts."
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -5,14 +5,15 @@
 # Diego Neves <diego@diegoneves.eti.br>, 2014, 2017.
 # Ronaldo Costa <ronaldocosta@oceanica.ufrj.br>, 2022.
 # Iago dos Santos <cdsiago@gmail.com>.2022.
+# Vinicius Madeira <viniciussmadeira@gmail.com>, 2024.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: 3.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-18 09:26-0500\n"
+"POT-Creation-Date: 2024-06-25 05:40-0300\n"
 "PO-Revision-Date: 2022-10-16 22:09-0300\n"
-"Last-Translator: Iago dos Santos <cdsiago@gmail.com>\n"
+"Last-Translator: Vinicius Madeira <viniciussmadeira@gmail.com>\n"
 "Language-Team: Brazilian Portuguese <ronaldocosta@oceanica.ufrj.br>\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
@@ -21,22 +22,39 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.1.1\n"
 
-#: src/weathericons.js:292 src/weathericons.js:294 src/weathericons.js:296
+#: src/openweathermap.js:88
+msgid "OpenWeather Refined Too Many Requests"
+msgstr "OpenWeather Refined - Muitas requisições"
+
+#: src/openweathermap.js:89
+#, javascript-format
+msgid ""
+"Provider %s has too many users. Try switching weather providers in settings."
+msgstr "O Provedor %s possui muitos usuários. Tente alterar o provedor nas configurações."
+
+#: src/openweathermap.js:137 src/preferences/aboutPage.js:88
+#: src/preferences/aboutPage.js:89
+msgid "Unknown"
+msgstr "Desconhecido"
+
+#: src/openweathermap.js:173
+msgid ", "
+msgstr ", "
+
+#: src/openweathermap.js:278
+msgid "Tomorrow"
+msgstr "Amanhã"
+
+#: src/weathericons.js:377 src/weathericons.js:379 src/weathericons.js:381
+#: src/weathericons.js:383
 msgid "Not available"
 msgstr "Não disponível"
 
-#: src/locs.js:101 src/locs.js:185 src/preferences/locationsPage.js:329
-#: src/preferences/locationsPage.js:393
-#, fuzzy
-msgid "My Location"
-msgstr "Locais"
-
 #: src/extension.js:248
 msgid "Failed to initialize."
-msgstr ""
+msgstr "Falha ao iniciar."
 
-#: src/extension.js:375
-#, fuzzy, javascript-format
+#: src/extension.js:382
 msgid ""
 "%s does not work without an api-key.\n"
 "Either set the switch to use the extensions default key in the preferences "
@@ -48,482 +66,289 @@ msgstr ""
 "se em https://openweathermap.org/appid e cole sua chave pessoal no dialogo "
 "de preferências."
 
-#: src/extension.js:432
+#: src/extension.js:439
 msgid "OpenWeather Refined: Imported settings from old extension."
-msgstr ""
+msgstr "OpenWeather Refined: Importe as configurações da extensão antiga."
 
-#: src/extension.js:745 src/extension.js:758
+#: src/extension.js:756 src/extension.js:769
 #, javascript-format
 msgid "Can not connect to %s"
 msgstr "Impossível conectar a %s"
 
-#: src/extension.js:1044 src/preferences/locationsPage.js:39
+#: src/extension.js:1043 src/preferences/locationsPage.js:39
 #: src/preferences/locationsPage.js:59
 msgid "Locations"
 msgstr "Locais"
 
-#: src/extension.js:1048
+#: src/extension.js:1047
 msgid "Reload Weather Information"
 msgstr "Recarregar informações meteorológicas"
 
-#: src/extension.js:1066
+#: src/extension.js:1065
 msgid "See Online"
-msgstr ""
+msgstr "Veja Online"
 
-#: src/extension.js:1071
+#: src/extension.js:1070
 msgid "Weather Settings"
 msgstr "Configurações do clima"
 
-#: src/extension.js:1099
+#: src/extension.js:1098
 msgid "Manual refreshes less than 2 minutes apart are ignored!"
 msgstr "Atualizações em menos de 2 minutos são ignoradas!"
 
-#: src/extension.js:1141
-#, fuzzy, javascript-format
+#: src/extension.js:1140
 msgid "Cannot open %s"
 msgstr "Impossível abrir %s"
 
-#: src/extension.js:1231 src/preferences/generalPage.js:194
+#: src/extension.js:1227 src/preferences/generalPage.js:214
 msgid "°C"
 msgstr "°C"
 
-#: src/extension.js:1234 src/preferences/generalPage.js:195
+#: src/extension.js:1230 src/preferences/generalPage.js:215
 msgid "°F"
 msgstr "°F"
 
-#: src/extension.js:1236 src/preferences/generalPage.js:196
+#: src/extension.js:1232 src/preferences/generalPage.js:216
 msgid "K"
 msgstr "K"
 
-#: src/extension.js:1238 src/preferences/generalPage.js:197
+#: src/extension.js:1234 src/preferences/generalPage.js:217
 msgid "°Ra"
 msgstr "°Ra"
 
-#: src/extension.js:1240 src/preferences/generalPage.js:198
+#: src/extension.js:1236 src/preferences/generalPage.js:218
 msgid "°Ré"
 msgstr "°Ré"
 
-#: src/extension.js:1242 src/preferences/generalPage.js:199
+#: src/extension.js:1238 src/preferences/generalPage.js:219
 msgid "°Rø"
 msgstr "°Rø"
 
-#: src/extension.js:1244 src/preferences/generalPage.js:200
+#: src/extension.js:1240 src/preferences/generalPage.js:220
 msgid "°De"
 msgstr "°De"
 
-#: src/extension.js:1246 src/preferences/generalPage.js:201
+#: src/extension.js:1242 src/preferences/generalPage.js:221
 msgid "°N"
 msgstr "°N"
 
-#: src/extension.js:1282
+#: src/extension.js:1250
 msgid "Calm"
 msgstr "Calmo"
 
-#: src/extension.js:1283
+#: src/extension.js:1251
 msgid "Light air"
 msgstr "Aragem"
 
-#: src/extension.js:1285
+#: src/extension.js:1253
 msgid "Light breeze"
 msgstr "Brisa leve"
 
-#: src/extension.js:1287
+#: src/extension.js:1255
 msgid "Gentle breeze"
 msgstr "Brisa fraca"
 
-#: src/extension.js:1289
+#: src/extension.js:1257
 msgid "Moderate breeze"
 msgstr "Brisa moderada"
 
-#: src/extension.js:1291
+#: src/extension.js:1259
 msgid "Fresh breeze"
 msgstr "Brisa forte"
 
-#: src/extension.js:1293
+#: src/extension.js:1261
 msgid "Strong breeze"
 msgstr "Vento fresco"
 
-#: src/extension.js:1295
+#: src/extension.js:1263
 msgid "Moderate gale"
 msgstr "Vento forte"
 
-#: src/extension.js:1297
+#: src/extension.js:1265
 msgid "Fresh gale"
 msgstr "Ventania"
 
-#: src/extension.js:1299
+#: src/extension.js:1267
 msgid "Strong gale"
 msgstr "Ventania forte"
 
-#: src/extension.js:1300
+#: src/extension.js:1268
 msgid "Storm"
 msgstr "Tempestade"
 
-#: src/extension.js:1302
+#: src/extension.js:1270
 msgid "Violent storm"
 msgstr "Tempestade violenta"
 
-#: src/extension.js:1303
+#: src/extension.js:1271
 msgid "Hurricane"
 msgstr "Furacão"
 
-#: src/extension.js:1308
+#: src/extension.js:1276
 msgid "Sunday"
 msgstr "Domingo"
 
-#: src/extension.js:1309
+#: src/extension.js:1277
 msgid "Monday"
 msgstr "Segunda-feira"
 
-#: src/extension.js:1310
+#: src/extension.js:1278
 msgid "Tuesday"
 msgstr "Terça-feira"
 
-#: src/extension.js:1311
+#: src/extension.js:1279
 msgid "Wednesday"
 msgstr "Quarta-feira"
 
-#: src/extension.js:1312
+#: src/extension.js:1280
 msgid "Thursday"
 msgstr "Quinta-feira"
 
-#: src/extension.js:1313
+#: src/extension.js:1281
 msgid "Friday"
 msgstr "Sexta-feira"
 
-#: src/extension.js:1314
+#: src/extension.js:1282
 msgid "Saturday"
 msgstr "Sábado"
 
-#: src/extension.js:1331
+#: src/extension.js:1299
 msgid "N"
 msgstr "N"
 
-#: src/extension.js:1332
+#: src/extension.js:1300
 msgid "NE"
 msgstr "NE"
 
-#: src/extension.js:1333
+#: src/extension.js:1301
 msgid "E"
-msgstr "E"
+msgstr "L"
 
-#: src/extension.js:1334
+#: src/extension.js:1302
 msgid "SE"
 msgstr "SE"
 
-#: src/extension.js:1335
+#: src/extension.js:1303
 msgid "S"
 msgstr "S"
 
-#: src/extension.js:1336
+#: src/extension.js:1304
 msgid "SW"
 msgstr "SO"
 
-#: src/extension.js:1337
+#: src/extension.js:1305
 msgid "W"
 msgstr "O"
 
-#: src/extension.js:1338
+#: src/extension.js:1306
 msgid "NW"
 msgstr "NO"
 
-#: src/extension.js:1427 src/preferences/generalPage.js:227
+#: src/extension.js:1395 src/preferences/generalPage.js:247
 msgid "inHg"
 msgstr "inHg"
 
-#: src/extension.js:1432 src/preferences/generalPage.js:228
+#: src/extension.js:1400 src/preferences/generalPage.js:248
 msgid "bar"
 msgstr "bar"
 
-#: src/extension.js:1437 src/preferences/generalPage.js:229
+#: src/extension.js:1405 src/preferences/generalPage.js:249
 msgid "Pa"
 msgstr "Pa"
 
-#: src/extension.js:1442 src/preferences/generalPage.js:230
+#: src/extension.js:1410 src/preferences/generalPage.js:250
 msgid "kPa"
 msgstr "kPa"
 
-#: src/extension.js:1447 src/preferences/generalPage.js:231
+#: src/extension.js:1415 src/preferences/generalPage.js:251
 msgid "atm"
 msgstr "atm"
 
-#: src/extension.js:1452 src/preferences/generalPage.js:232
+#: src/extension.js:1420 src/preferences/generalPage.js:252
 msgid "at"
 msgstr "at"
 
-#: src/extension.js:1457 src/preferences/generalPage.js:233
+#: src/extension.js:1425 src/preferences/generalPage.js:253
 msgid "Torr"
 msgstr "Torr"
 
-#: src/extension.js:1462 src/preferences/generalPage.js:234
+#: src/extension.js:1430 src/preferences/generalPage.js:254
 msgid "psi"
 msgstr "psi"
 
-#: src/extension.js:1467 src/preferences/generalPage.js:235
+#: src/extension.js:1435 src/preferences/generalPage.js:255
 msgid "mmHg"
 msgstr "mmHg"
 
-#: src/extension.js:1471 src/preferences/generalPage.js:236
+#: src/extension.js:1439 src/preferences/generalPage.js:256
 msgid "mbar"
 msgstr "mbar"
 
-#: src/extension.js:1537 src/preferences/generalPage.js:214
+#: src/extension.js:1507 src/preferences/generalPage.js:234
 msgid "m/s"
 msgstr "m/s"
 
-#: src/extension.js:1542 src/preferences/generalPage.js:213
+#: src/extension.js:1512 src/preferences/generalPage.js:233
 msgid "mph"
 msgstr "mph"
 
-#: src/extension.js:1547 src/preferences/generalPage.js:212
+#: src/extension.js:1517 src/preferences/generalPage.js:232
 msgid "km/h"
 msgstr "km/h"
 
-#: src/extension.js:1556 src/preferences/generalPage.js:215
+#: src/extension.js:1526 src/preferences/generalPage.js:235
 msgid "kn"
 msgstr "kn"
 
-#: src/extension.js:1561 src/preferences/generalPage.js:216
+#: src/extension.js:1531 src/preferences/generalPage.js:236
 msgid "ft/s"
 msgstr "ft/s"
 
-#: src/extension.js:1628 src/extension.js:1678
+#: src/extension.js:1601 src/extension.js:1651
 msgid "Loading ..."
 msgstr "Carregando ..."
 
-#: src/extension.js:1682
+#: src/extension.js:1655
 msgid "Please wait"
 msgstr "Espere um momento"
 
-#: src/extension.js:1739
+#: src/extension.js:1712
 msgid "Feels Like:"
 msgstr "Sensação térmica:"
 
-#: src/extension.js:1740
+#: src/extension.js:1713
 msgid "Humidity:"
 msgstr "Umidade:"
 
-#: src/extension.js:1741
+#: src/extension.js:1714
 msgid "Pressure:"
 msgstr "Pressão:"
 
-#: src/extension.js:1742
+#: src/extension.js:1715
 msgid "Wind:"
 msgstr "Vento:"
 
-#: src/extension.js:1743
-#, fuzzy
+#: src/extension.js:1716
 msgid "Gusts"
-msgstr "Rajadas:"
+msgstr "Rajadas"
 
-#: src/extension.js:1925
+#: src/extension.js:1898
 msgid "Tomorrow's Forecast"
 msgstr "Previsão de amanhã"
 
-#: src/extension.js:1926
+#: src/extension.js:1899
 #, javascript-format
 msgid "%s Day Forecast"
 msgstr "Previsão para %s dias"
 
-#: src/openweathermap.js:139
-msgid ", "
-msgstr ", "
-
-#: src/openweathermap.js:238
-msgid "Tomorrow"
-msgstr "Amanhã"
-
-#: src/preferences/generalPage.js:28
-#, fuzzy, javascript-format
-msgid "%s Multilingual Support"
-msgstr "Suporte multilingual OpenWeatherMap"
-
-#: src/preferences/generalPage.js:33
-#, fuzzy, javascript-format
-msgid "Use a personal API key for %s"
-msgstr "Key API a ser usada"
-
-#: src/preferences/generalPage.js:38
-#, fuzzy, javascript-format
-msgid "Enable this if you have your own API key from %s and enter it below."
-msgstr ""
-"Desative se você tiver a sua api-key do openweathermap.org e adicione na "
-"caixa de texto a seguir."
-
-#: src/preferences/generalPage.js:51
-msgid "Settings"
-msgstr "Configurações"
-
-#: src/preferences/generalPage.js:60
-msgid "General"
-msgstr "Geral"
-
-#: src/preferences/generalPage.js:78
-msgid "Current Weather Refresh"
-msgstr "Intervalo de atualização do clima atual"
-
-#: src/preferences/generalPage.js:79
-msgid "Current weather refresh interval in minutes"
-msgstr "Intervalo de atualização do clima atual em minutos"
-
-#: src/preferences/generalPage.js:101
-msgid "Weather Forecast Refresh"
-msgstr "Intervalo de atualização da previsão"
-
-#: src/preferences/generalPage.js:102
-msgid "Forecast refresh interval in minutes if enabled"
-msgstr "Intervalo de atualização da previsão em minutos, se habilitado"
-
-#: src/preferences/generalPage.js:122
-#, fuzzy
-msgid "My Location Refresh"
-msgstr "Locais"
-
-#: src/preferences/generalPage.js:123
-#, fuzzy
-msgid "My location refresh interval in minutes"
-msgstr "Intervalo de atualização do clima atual em minutos"
-
-#: src/preferences/generalPage.js:134
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:122
-msgid "Disable Forecast"
-msgstr "Desativar previsão"
-
-#: src/preferences/generalPage.js:135
-msgid "Disables all fetching and processing of forecast data"
-msgstr "Desativar a atualização e processamento de dados de previsão"
-
-#: src/preferences/generalPage.js:146
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:110
-msgid "System Icons"
-msgstr "Ícones do sistema"
-
-#: src/preferences/generalPage.js:147
-#, fuzzy, javascript-format
-msgid "Disable to use packaged %s weather icons"
-msgstr "Desabilitar para utilizar o pacotes de icones Adwaita"
-
-#: src/preferences/generalPage.js:149
-msgid ""
-"If you have issues with your system icons displaying correctly disable this "
-"to fix it"
-msgstr "Desabilite essa opção se ouver conflito com os icones do sistema"
-
-#: src/preferences/generalPage.js:170
-msgid "First Boot Delay"
-msgstr "Atraso na primeira incialização"
-
-#: src/preferences/generalPage.js:171
-msgid "Seconds to delay popup initialization and data fetching"
-msgstr "Atraso em segundos desde a incialização para atualizar os dados"
-
-#: src/preferences/generalPage.js:173
-msgid ""
-"This setting only applies to the first time the extension is loaded. (first "
-"log in / restarting gnome shell)"
-msgstr ""
-"Isso só se aplica na primeira vez que a extensão é carregada na gnome shell"
-
-#: src/preferences/generalPage.js:189
-msgid "Units"
-msgstr "Unidades"
-
-#: src/preferences/generalPage.js:205
-msgid "Temperature"
-msgstr "Temperatura"
-
-#: src/preferences/generalPage.js:217
-msgid "Beaufort"
-msgstr "Beaufort"
-
-#: src/preferences/generalPage.js:219
-msgid "Wind Speed"
-msgstr "Velocidade do vento"
-
-#: src/preferences/generalPage.js:238
-msgid "Pressure"
-msgstr "Pressão"
-
-#: src/preferences/generalPage.js:245
-msgid "24-hour"
-msgstr ""
-
-#: src/preferences/generalPage.js:246
-msgid "AM / PM"
-msgstr ""
-
-#: src/preferences/generalPage.js:247
-#, fuzzy
-msgid "System"
-msgstr "Ícones do sistema"
-
-#: src/preferences/generalPage.js:249
-msgid "Time Format"
-msgstr ""
-
-#: src/preferences/generalPage.js:260
-msgid "Simplify Degrees"
-msgstr ""
-
-#: src/preferences/generalPage.js:261
-msgid "Show \"°\" instead of \"°C,\" \"°F,\" etc."
-msgstr ""
-
-#: src/preferences/generalPage.js:262
-msgid "Enable this to cut off the \"C,\" \"F,\" etc. from degrees labels."
-msgstr ""
-
-#: src/preferences/generalPage.js:276 src/preferences/locationsPage.js:67
-msgid "Provider"
-msgstr "Fornecedor"
-
-#: src/preferences/generalPage.js:287
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:67
-msgid "Weather Provider"
-msgstr "Meteorologia fornecida por"
-
-#: src/preferences/generalPage.js:288
-#, fuzzy
-msgid "Provider used for weather and forecasts"
-msgstr "Provedor utilizado para os dados de localização"
-
-#: src/preferences/generalPage.js:301
-msgid "Using provider translations applies to weather conditions only"
-msgstr "Usar a tradução providenciada se aplica apenas as condições do clima"
-
-#: src/preferences/generalPage.js:304
-#, fuzzy
-msgid ""
-"Enable this to use provider multilingual support if there's no built-in "
-"translations for your language yet."
-msgstr ""
-"Habilite isso para usar o suporte multilinguístico OWM em 46 linguagens se "
-"não existe tradução para a sua linguagem."
-
-#: src/preferences/generalPage.js:317
-#, fuzzy
-msgid "Use Custom API Key"
-msgstr "Usar a API key da extensão"
-
-#: src/preferences/generalPage.js:333
-msgid "Personal API Key"
-msgstr "Key API a ser usada"
-
-#: src/preferences/generalPage.js:369 src/preferences/generalPage.js:375
-msgid "Reset"
-msgstr ""
-
-#: src/preferences/generalPage.js:379
-msgid "Restore Defaults"
-msgstr ""
-
-#: src/preferences/generalPage.js:381
-msgid "Restore all settings to the defaults."
-msgstr ""
+#: src/locs.js:102 src/locs.js:186 src/preferences/locationsPage.js:331
+#: src/preferences/locationsPage.js:395
+msgid "My Location"
+msgstr "Minha localização"
 
 #: src/preferences/layoutPage.js:31
 msgid "Layout"
-msgstr "Aparencia"
+msgstr "Aparência"
 
 #: src/preferences/layoutPage.js:39
 msgid "Panel"
@@ -570,23 +395,22 @@ msgid "Conditions In Panel"
 msgstr "Condições no painel"
 
 #: src/preferences/layoutPage.js:102
-#, fuzzy
 msgid "Show the time of sunrise/sunset in the panel."
-msgstr "Mostrar a temperatura no painel"
+msgstr "Mostrar o horário do nascer/pôr do sol no painel."
 
 #: src/preferences/layoutPage.js:106
-#, fuzzy
 msgid "Sunrise/Sunset In Panel"
-msgstr "Condições no painel"
+msgstr "Nascer/Pôr do sol no painel"
 
 #: src/preferences/layoutPage.js:114
 msgid ""
 "Show the sunset/sunrise before the temperature/conditions. Requires restart."
 msgstr ""
+"Mostrar nascer/pôr do sol antes da temperatura/condições. Requer reinicialização."
 
 #: src/preferences/layoutPage.js:118
 msgid "Sunrise/Sunset First (Restart Required)"
-msgstr ""
+msgstr "Nascer/pôr do sol primeiro (Requer reinicialização)"
 
 #: src/preferences/layoutPage.js:134
 msgid "Popup"
@@ -605,7 +429,7 @@ msgid "Wind Direction Arrows"
 msgstr "Direção do vento usando setas"
 
 #: src/preferences/layoutPage.js:176
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:102
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:103
 msgid "Translate Conditions"
 msgstr "Traduzir condições"
 
@@ -615,23 +439,23 @@ msgid "0"
 msgstr "0"
 
 #: src/preferences/layoutPage.js:185 src/preferences/layoutPage.js:199
-#: src/preferences/layoutPage.js:213 src/preferences/layoutPage.js:302
+#: src/preferences/layoutPage.js:213
 msgid "1"
 msgstr "1"
 
 #: src/preferences/layoutPage.js:186 src/preferences/layoutPage.js:200
-#: src/preferences/layoutPage.js:214 src/preferences/layoutPage.js:303
+#: src/preferences/layoutPage.js:214
 msgid "2"
 msgstr "2"
 
 #: src/preferences/layoutPage.js:187 src/preferences/layoutPage.js:201
-#: src/preferences/layoutPage.js:215 src/preferences/layoutPage.js:304
+#: src/preferences/layoutPage.js:215
 msgid "3"
 msgstr "3"
 
 #: src/preferences/layoutPage.js:189
 msgid "Temperature Decimal Places"
-msgstr "Digitos decimais da temperatura"
+msgstr "Digitos decimais da Temperatura"
 
 #: src/preferences/layoutPage.js:190 src/preferences/layoutPage.js:205
 #: src/preferences/layoutPage.js:219
@@ -640,26 +464,23 @@ msgstr "Numero máximo de dígitos decimais no painel"
 
 #: src/preferences/layoutPage.js:196
 msgid "Unit Default"
-msgstr ""
+msgstr "Unidade Padrão"
 
 #: src/preferences/layoutPage.js:197 src/preferences/layoutPage.js:211
 msgid "Follow Temp."
-msgstr ""
+msgstr "Igual a Temp."
 
 #: src/preferences/layoutPage.js:202 src/preferences/layoutPage.js:216
-#: src/preferences/layoutPage.js:305
 msgid "4"
 msgstr "4"
 
 #: src/preferences/layoutPage.js:204
-#, fuzzy
 msgid "Pressure Decimal Places"
-msgstr "Digitos decimais da temperatura"
+msgstr "Digitos decimais da Pressão"
 
 #: src/preferences/layoutPage.js:218
-#, fuzzy
 msgid "Speed Decimal Places"
-msgstr "Digitos decimais da temperatura"
+msgstr "Digitos decimais da Velocidade"
 
 #: src/preferences/layoutPage.js:239
 msgid "Location Text Length"
@@ -669,56 +490,220 @@ msgstr "Tamanho do texto de local"
 msgid "Maximum length of the location text. A setting of '0' is unlimited"
 msgstr "Tamanho máximo do texto de localização. '0' indica sem limite"
 
-#: src/preferences/layoutPage.js:249
-msgid "Off"
-msgstr ""
+#: src/preferences/layoutPage.js:243
+msgid "Maximum length to cut off the location text at. \"0\" is unlimited."
+msgstr "Tamanho máximo do texto de localização. '0' indica sem limite"
 
 #: src/preferences/layoutPage.js:250
-msgid "White Text"
-msgstr ""
+msgid "Off"
+msgstr "Desligado"
 
 #: src/preferences/layoutPage.js:251
-msgid "Black Text"
-msgstr ""
+msgid "White Text"
+msgstr "Texto em branco"
 
-#: src/preferences/layoutPage.js:253
-msgid "High Contrast"
-msgstr ""
+#: src/preferences/layoutPage.js:252
+msgid "Black Text"
+msgstr "Texto em preto"
 
 #: src/preferences/layoutPage.js:254
-msgid "Enable to override GNOME shell colors"
-msgstr ""
+msgid "High Contrast"
+msgstr "Alto contraste"
 
-#: src/preferences/layoutPage.js:273
+#: src/preferences/layoutPage.js:255
+msgid ""
+"Override GNOME shell text colors in the pop-up with hard-coded ones that may "
+"be easier to read. This may not be very effective depending on your shell "
+"theme."
+msgstr ""
+"Sobrescreva as cores de texto do GNOME shell no pop-up com valores pré-definidos "
+"que possam ser mais fáceis de serem lidos. Pode não ser efetivo dependendo do "
+"tema do seu gnome shell."
+
+#: src/preferences/layoutPage.js:256
+msgid "Enable to override GNOME shell colors"
+msgstr "Habilite para sobrescrever as cores do shell GNOME"
+
+#: src/preferences/layoutPage.js:275
 msgid "Forecast"
 msgstr "Previsão"
 
-#: src/preferences/layoutPage.js:283
+#: src/preferences/layoutPage.js:285
 msgid "Center Today's Forecast"
-msgstr "Previsão Central do Dia"
+msgstr "Centralizar previsão do dia"
 
-#: src/preferences/layoutPage.js:294
+#: src/preferences/layoutPage.js:286
+msgid "Center today's forecast instead of left-aligning it."
+msgstr "Centralize a previsão do dia ao invés de alinhar à esquerda."
+
+#: src/preferences/layoutPage.js:297
 msgid "Conditions In Forecast"
 msgstr "Condições na previsão"
 
-#: src/preferences/layoutPage.js:301
-msgid "Today Only"
-msgstr "Apenas hoje"
+#: src/preferences/layoutPage.js:298
+msgid "Show the condition text (e.g. \"Cloudy\") in the forecast."
+msgstr "Exibir o texto da condição (ex: 'Nublado') na previsão."
 
-#: src/preferences/layoutPage.js:306
-msgid "5"
-msgstr "5"
-
-#: src/preferences/layoutPage.js:308
+#: src/preferences/layoutPage.js:318
 msgid "Total Days In Forecast"
 msgstr "Total de Dias na Previsão"
 
-#: src/preferences/layoutPage.js:319
+#: src/preferences/layoutPage.js:320
+msgid ""
+"Number of days to show in forecast where a setting of \"0\" is only today"
+msgstr "Número de dias para exibir a previsão."
+
+#: src/preferences/layoutPage.js:322
+#, javascript-format
+msgid ""
+"Number of days to show in forecast. \"0\" means only show today.\n"
+"Different providers support different amounts of days.\n"
+"Currently \"%s\" supports the furthest forecast of %s days."
+msgstr ""
+"Número de dias a exibir na previsão. \"0\" só exibirá hoje.\n"
+"Provedores diferentes suportam diferentes quantias de dias.\n"
+"Atualmente o \"%s\" suporta previsões até %s dias."
+
+#: src/preferences/layoutPage.js:333
 msgid "Keep Forecast Expanded"
 msgstr "Manter a previsão extendida"
 
+#: src/preferences/layoutPage.js:334
+msgid "Automatically open the forecast when the pop-up is opened."
+msgstr "Abrir a previsão automaticamente quando o pop-up for aberto."
+
+#: src/preferences/locationsPage.js:55
+msgid "Add"
+msgstr "Adicionar"
+
+#: src/preferences/locationsPage.js:67 src/preferences/generalPage.js:35
+#: src/preferences/generalPage.js:42 src/preferences/generalPage.js:315
+msgid "Provider"
+msgstr "Fornecedor"
+
+#: src/preferences/locationsPage.js:75
+msgid "My Loc. Provider"
+msgstr "Fornecedor"
+
+#: src/preferences/locationsPage.js:76
+msgid "Provider for getting My Location"
+msgstr "Provedor utilizado para os dados de localização"
+
+#: src/preferences/locationsPage.js:85
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:72
+msgid "Geolocation Provider"
+msgstr "Geolocalização fornecida por"
+
+#: src/preferences/locationsPage.js:86
+msgid "Provider used for location search"
+msgstr "Provedor utilizado para os dados de localização"
+
+#: src/preferences/locationsPage.js:99
+msgid "Personal MapQuest Key"
+msgstr "Key do MapQuest"
+
+#: src/preferences/locationsPage.js:100
+msgid "Personal API Key from developer.mapquest.com"
+msgstr "AppKey pessoal do developer.mapquest.com"
+
+#: src/preferences/locationsPage.js:264
+#, javascript-format
+msgid "Location changed to: %s"
+msgstr "Local alterado para: %s"
+
+#: src/preferences/locationsPage.js:294
+msgid "Add New Location"
+msgstr "Adicionar Novo Local"
+
+#: src/preferences/locationsPage.js:315
+msgid "Search by Location or Coordinates"
+msgstr "Procurar por Local ou Coordenadas"
+
+#: src/preferences/locationsPage.js:321
+msgid "e.g. London, England or 51.5074456,-0.1277653"
+msgstr "e.g São Paulo, Brasil ou -23.5489, -46.6388"
+
+#: src/preferences/locationsPage.js:323 src/preferences/locationsPage.js:451
+#: src/preferences/locationsPage.js:468
+msgid "Clear entry"
+msgstr "Limpo"
+
+#: src/preferences/locationsPage.js:340
+msgid "Search"
+msgstr "Pesquisa"
+
+#: src/preferences/locationsPage.js:366
+msgid "We need something to search for!"
+msgstr "Insira algum valor para a pesquisa!"
+
+#: src/preferences/locationsPage.js:395
+#: src/preferences/searchResultsWindow.js:273
+#, javascript-format
+msgid "%s has been added"
+msgstr "%s foi adicionado"
+
+#: src/preferences/locationsPage.js:411
+#, javascript-format
+msgid "Edit %s"
+msgstr "Editar %s"
+
+#: src/preferences/locationsPage.js:433
+msgid "Edit Name"
+msgstr "Editar Nome"
+
+#: src/preferences/locationsPage.js:459
+msgid "Edit Coordinates"
+msgstr "Editar Coordenadas"
+
+#: src/preferences/locationsPage.js:475
+msgid ""
+"If you meant to search up a new location by name, <b>add</b> a location "
+"instead."
+msgstr ""
+"Se você pretendia procurar uma nova localização por nome, <b>adicione</b> uma localização. "
+
+#: src/preferences/locationsPage.js:484
+msgid "Save"
+msgstr "Salvar"
+
+#: src/preferences/locationsPage.js:519
+msgid "Coordinates field cannot be empty."
+msgstr "O campo de coordenadas não pode estar vazio."
+
+#: src/preferences/locationsPage.js:527
+#, javascript-format
+msgid "Coordinates field must be in the format of '%s' or the text '%s'."
+msgstr "O campo de coordenadas deve estar no formato '%s' ou o texto '%s'."
+
+#: src/preferences/locationsPage.js:535
+#, javascript-format
+msgid "Name field can only be empty if coordinates are '%s'."
+msgstr "O campo de nome só pode estar vazio se as coordenadas forem '%s'."
+
+#: src/preferences/locationsPage.js:564
+#, javascript-format
+msgid "%s has been updated"
+msgstr "%s foi atualizado"
+
+#: src/preferences/locationsPage.js:595
+#, javascript-format
+msgid "Are you sure you want to delete \"%s\"?"
+msgstr "Você tem certeza que quer apagar \"%s\"?"
+
+#: src/preferences/locationsPage.js:603
+msgid "Delete"
+msgstr "Apagar"
+
+#: src/preferences/locationsPage.js:607
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: src/preferences/locationsPage.js:636
+#, javascript-format
+msgid "%s has been deleted"
+msgstr "%s foi apagado"
+
 #: src/preferences/searchResultsWindow.js:36
-#, fuzzy, javascript-format
 msgid "Search Results from %s"
 msgstr "Procurar resultados"
 
@@ -737,24 +722,18 @@ msgstr "Aguarde, pesquisando locais com \"%s\""
 
 #: src/preferences/searchResultsWindow.js:117
 msgid "AppKey Required"
-msgstr "AppKey necesaria"
+msgstr "AppKey necessária"
 
 #: src/preferences/searchResultsWindow.js:119
 #, javascript-format
 msgid "You need an AppKey to use MapQuest, get one at: %s"
 msgstr ""
-"Você precisa de uma AppKey para usar o MapQuest.Você pode gerar uma em: %s"
+"Você precisa de uma AppKey para usar o MapQuest. Você pode gerar uma em: %s"
 
 #: src/preferences/searchResultsWindow.js:207
 #, javascript-format
 msgid "Results for \"%s\""
 msgstr "Resultados para \"%s\""
-
-#: src/preferences/searchResultsWindow.js:273
-#: src/preferences/locationsPage.js:393
-#, javascript-format
-msgid "%s has been added"
-msgstr "%s foi adicionado"
 
 #: src/preferences/searchResultsWindow.js:284
 msgid "API Error"
@@ -774,218 +753,298 @@ msgstr "Nenhum resultado encontrado"
 msgid "No results found when searching for \"%s\"."
 msgstr "Sem resultados de busca para \"%s\"."
 
-#: src/preferences/aboutPage.js:36
+#: src/preferences/aboutPage.js:45
 msgid "About"
 msgstr "Sobre"
 
-#: src/preferences/aboutPage.js:64
-#, fuzzy
+#: src/preferences/aboutPage.js:73
 msgid ""
 "Display weather information for any location on Earth in the GNOME Shell."
 msgstr ""
-"Exiba informações meteorológicas de qualquer lugar da Terra no GNOME Shell"
+"Exibe informações meteorológicas de qualquer lugar da Terra no GNOME Shell"
 
-#: src/preferences/aboutPage.js:79 src/preferences/aboutPage.js:80
-#, fuzzy
-msgid "Unknown"
-msgstr "desconhecido"
-
-#: src/preferences/aboutPage.js:84
-#, fuzzy
+#: src/preferences/aboutPage.js:93
 msgid "OpenWeather Refined Version"
 msgstr "Versão do OpenWeather"
 
-#: src/preferences/aboutPage.js:96
+#: src/preferences/aboutPage.js:105
 msgid "Git Version"
 msgstr "Versão do Git"
 
-#: src/preferences/aboutPage.js:107
+#: src/preferences/aboutPage.js:116
 msgid "GNOME Version"
 msgstr "Versão do GNOME"
 
-#: src/preferences/aboutPage.js:117
-#, fuzzy
+#: src/preferences/aboutPage.js:126
 msgid "Copy Settings JSON"
-msgstr "Configurações"
+msgstr "Copiar JSON de configurações"
 
-#: src/preferences/aboutPage.js:120
+#: src/preferences/aboutPage.js:129
 msgid "Copy"
-msgstr ""
+msgstr "Copiar"
 
-#: src/preferences/aboutPage.js:167
+#: src/preferences/aboutPage.js:134
+msgid "Paste"
+msgstr "Colar"
+
+#: src/preferences/aboutPage.js:203
 msgid "Copied settings JSON to clipboard."
-msgstr ""
+msgstr "Configurações JSON copiadas para a área de transferência."
 
-#: src/preferences/aboutPage.js:188
+#: src/preferences/aboutPage.js:219
+msgid "Clipboard contains no text."
+msgstr "Sua área de transferência não possui texto."
+
+#: src/preferences/aboutPage.js:226
+msgid "Clipboard didn't contain valid JSON."
+msgstr "Sua área de transferência não possuía JSON válido."
+
+#: src/preferences/aboutPage.js:269
 #, javascript-format
 msgid "Maintained by: %s"
 msgstr "Mantido por: %s"
 
-#: src/preferences/aboutPage.js:194
+#: src/preferences/aboutPage.js:275
 #, javascript-format
 msgid "Contribute or translate the project on %s."
-msgstr ""
+msgstr "Contribua ou traduza este projeto em %s."
 
-#: src/preferences/aboutPage.js:200
+#: src/preferences/aboutPage.js:281
 #, javascript-format
 msgid "This is a fork of %s's extension."
-msgstr ""
+msgstr "Este projeto é um 'fork' da extensão do %s."
 
-#: src/preferences/aboutPage.js:222
+#: src/preferences/aboutPage.js:306
 #, javascript-format
 msgid "Weather data provided by: %s"
 msgstr "Dados meteorológicos por: %s"
 
-#: src/preferences/aboutPage.js:236
+#: src/preferences/aboutPage.js:321
 msgid "This program comes with ABSOLUTELY NO WARRANTY."
 msgstr "Esse programa não contem nenhum tipo de garantia."
 
-#: src/preferences/aboutPage.js:238
+#: src/preferences/aboutPage.js:323
 msgid "See the"
 msgstr "Consulte a"
 
-#: src/preferences/aboutPage.js:240
+#: src/preferences/aboutPage.js:325
 msgid "GNU General Public License, version 2 or later"
 msgstr "Licença Pública Geral GNU, versão 2 ou posterior"
 
-#: src/preferences/aboutPage.js:242
+#: src/preferences/aboutPage.js:327
 msgid "for details."
 msgstr "para detalhes."
 
-#: src/preferences/locationsPage.js:55
-msgid "Add"
-msgstr "Adicionar"
+#: src/preferences/generalPage.js:29
+msgid "Provider Multilingual Support"
+msgstr "Suporte Multi-idiomas do Provedor"
 
-#: src/preferences/locationsPage.js:75
-#, fuzzy
-msgid "My Loc. Provider"
-msgstr "Fornecedor"
+#: src/preferences/generalPage.js:35
+msgid "Use a personal API key for %s"
+msgstr "Key API a ser usada"
 
-#: src/preferences/locationsPage.js:76
-#, fuzzy
-msgid "Provider for getting My Location"
-msgstr "Provedor utilizado para os dados de localização"
-
-#: src/preferences/locationsPage.js:85
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:71
-msgid "Geolocation Provider"
-msgstr "Geolocalização fornecida por"
-
-#: src/preferences/locationsPage.js:86
-msgid "Provider used for location search"
-msgstr "Provedor utilizado para os dados de localização"
-
-#: src/preferences/locationsPage.js:99
-msgid "Personal MapQuest Key"
-msgstr "Key do MapQuest"
-
-#: src/preferences/locationsPage.js:100
-msgid "Personal API Key from developer.mapquest.com"
-msgstr "AppKey pessoal do developer.mapquest.com"
-
-#: src/preferences/locationsPage.js:262
-#, javascript-format
-msgid "Location changed to: %s"
-msgstr "Local alterado para: %s"
-
-#: src/preferences/locationsPage.js:292
-msgid "Add New Location"
-msgstr "Adicionar Novo Local"
-
-#: src/preferences/locationsPage.js:313
-msgid "Search by Location or Coordinates"
-msgstr "Procurar por Local ou Coordenadas"
-
-#: src/preferences/locationsPage.js:319
-msgid "e.g. London, England or 51.5074456,-0.1277653"
+#: src/preferences/generalPage.js:41
+msgid "Enable this if you have your own API key from %s and enter it below."
 msgstr ""
+"Desative se você tiver a sua api-key do openweathermap.org e adicione na "
+"caixa de texto a seguir."
 
-#: src/preferences/locationsPage.js:321 src/preferences/locationsPage.js:449
-#: src/preferences/locationsPage.js:466
-msgid "Clear entry"
-msgstr "Limpo"
+#: src/preferences/generalPage.js:71
+msgid "Settings"
+msgstr "Configurações"
 
-#: src/preferences/locationsPage.js:338
-msgid "Search"
-msgstr "Pesquisa"
+#: src/preferences/generalPage.js:80
+msgid "General"
+msgstr "Geral"
 
-#: src/preferences/locationsPage.js:364
-msgid "We need something to search for!"
-msgstr "Adicione algum argumento para a pesquisa!"
+#: src/preferences/generalPage.js:98
+msgid "Current Weather Refresh"
+msgstr "Intervalo de atualização do clima atual"
 
-#: src/preferences/locationsPage.js:409
-#, javascript-format
-msgid "Edit %s"
-msgstr "Editar %s"
+#: src/preferences/generalPage.js:99
+msgid "Current weather refresh interval in minutes"
+msgstr "Intervalo de atualização do clima atual em minutos"
 
-#: src/preferences/locationsPage.js:431
-msgid "Edit Name"
-msgstr "Editar Nome"
+#: src/preferences/generalPage.js:121
+msgid "Weather Forecast Refresh"
+msgstr "Intervalo de atualização da previsão"
 
-#: src/preferences/locationsPage.js:457
-msgid "Edit Coordinates"
-msgstr "Editar Coordenadas"
+#: src/preferences/generalPage.js:122
+msgid "Forecast refresh interval in minutes if enabled"
+msgstr "Intervalo de atualização da previsão em minutos, se habilitado"
 
-#: src/preferences/locationsPage.js:473
+#: src/preferences/generalPage.js:142
+msgid "My Location Refresh"
+msgstr "Atualizar minha localização"
+
+#: src/preferences/generalPage.js:143
+msgid "My location refresh interval in minutes"
+msgstr "Intervalo de atualização do clima atual em minutos"
+
+#: src/preferences/generalPage.js:154
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:123
+msgid "Disable Forecast"
+msgstr "Desativar previsão"
+
+#: src/preferences/generalPage.js:155
+msgid "Disables all fetching and processing of forecast data"
+msgstr "Desativar a atualização e processamento de dados de previsão"
+
+#: src/preferences/generalPage.js:166
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:111
+msgid "System Icons"
+msgstr "Ícones do sistema"
+
+#: src/preferences/generalPage.js:167
+msgid "Disable to use packaged %s weather icons"
+msgstr "Desabilitar para utilizar o pacotes de ícones %s"
+
+#: src/preferences/generalPage.js:169
 msgid ""
-"If you meant to search up a new location by name, <b>add</b> a location "
-"instead."
+"If you have issues with your system icons displaying correctly disable this "
+"to fix it"
+msgstr "Desabilite essa opção se houver conflito com os ícones do sistema"
+
+#: src/preferences/generalPage.js:190
+msgid "First Boot Delay"
+msgstr "Atraso na primeira incialização"
+
+#: src/preferences/generalPage.js:191
+msgid "Seconds to delay popup initialization and data fetching"
+msgstr "Atraso em segundos desde a incialização para atualizar os dados"
+
+#: src/preferences/generalPage.js:193
+msgid ""
+"This setting only applies to the first time the extension is loaded. (first "
+"log in / restarting gnome shell)"
 msgstr ""
+"Isso só se aplica na primeira vez que a extensão é carregada no gnome shell"
 
-#: src/preferences/locationsPage.js:482
-msgid "Save"
-msgstr "Salvar"
+#: src/preferences/generalPage.js:209
+msgid "Units"
+msgstr "Unidades"
 
-#: src/preferences/locationsPage.js:517
-msgid "Coordinates field cannot be empty."
+#: src/preferences/generalPage.js:225
+msgid "Temperature"
+msgstr "Temperatura"
+
+#: src/preferences/generalPage.js:237
+msgid "Beaufort"
+msgstr "Beaufort"
+
+#: src/preferences/generalPage.js:239
+msgid "Wind Speed"
+msgstr "Velocidade do vento"
+
+#: src/preferences/generalPage.js:258
+msgid "Pressure"
+msgstr "Pressão"
+
+#: src/preferences/generalPage.js:265
+msgid "24-hour"
+msgstr "24 horas"
+
+#: src/preferences/generalPage.js:266
+msgid "AM / PM"
+msgstr "12 horas"
+
+#: src/preferences/generalPage.js:267
+msgid "System"
+msgstr "Sistema"
+
+#: src/preferences/generalPage.js:269
+msgid "Time Format"
+msgstr "Formato do horário"
+
+#: src/preferences/generalPage.js:280
+msgid "Simplify Degrees"
+msgstr "Simplificar graus"
+
+#: src/preferences/generalPage.js:281
+msgid "Show \"°\" instead of \"°C,\" \"°F,\" etc."
+msgstr "Exibir '°' no lugar de '°C', '°F,' etc."
+
+#: src/preferences/generalPage.js:282
+msgid "Enable this to cut off the \"C,\" \"F,\" etc. from degrees labels."
+msgstr "Habilite isto para tirar o 'C', 'F', etc. dos rótulos de graus."
+
+#: src/preferences/generalPage.js:295
+msgid "Notifications"
+msgstr "Notificações"
+
+#: src/preferences/generalPage.js:303
+msgid "Precipitation Starting"
+msgstr "Início da precipitação"
+
+#: src/preferences/generalPage.js:304 src/preferences/generalPage.js:305
+msgid "Get notified when precipitation starts (e.g. rain or snow)."
+msgstr "Seja notificado quando começar a precipitar (ex: chuva ou neve)."
+
+#: src/preferences/generalPage.js:322 src/preferences/generalPage.js:329
+#: src/preferences/generalPage.js:330
+msgid "Adaptive"
+msgstr "Adaptativo"
+
+#: src/preferences/generalPage.js:328
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:68
+msgid "Weather Provider"
+msgstr "Meteorologia fornecida por"
+
+#: src/preferences/generalPage.js:329
+msgid ""
+"Provider used for weather and forecasts; choose \"%s\" if you don't care."
+msgstr "Provedor utilizado para os dados de localização"
+
+#: src/preferences/generalPage.js:330
+#, javascript-format
+msgid "Choose '%s' if you don't care, otherwise choose a specific provider."
+msgstr "Escolha '%s' se você não se incomoda, caso contrário, escolha um provedor específico."
+
+#: src/preferences/generalPage.js:343
+msgid "Using provider translations applies to weather conditions only"
+msgstr "Usar a tradução providenciada se aplica apenas as condições do clima"
+
+#: src/preferences/generalPage.js:346
+msgid ""
+"Enable this to use provider multilingual support if there's no built-in "
+"translations for your language yet."
 msgstr ""
+"Habilite isso para usar o suporte multilinguístico OWM em 46 linguagens se "
+"não existe tradução para a sua linguagem."
 
-#: src/preferences/locationsPage.js:525
-#, javascript-format
-msgid "Coordinates field must be in the format of '%s' or the text '%s'."
-msgstr ""
+#: src/preferences/generalPage.js:361
+msgid "Use Custom API Key"
+msgstr "Usar a API key da extensão"
 
-#: src/preferences/locationsPage.js:533
-#, javascript-format
-msgid "Name field can only be empty if coordinates are '%s'."
-msgstr ""
+#: src/preferences/generalPage.js:377
+msgid "Personal API Key"
+msgstr "Key API a ser usada"
 
-#: src/preferences/locationsPage.js:562
-#, javascript-format
-msgid "%s has been updated"
-msgstr "%s foi atualizado"
+#: src/preferences/generalPage.js:394 src/preferences/generalPage.js:400
+msgid "Reset"
+msgstr "Restaurar"
 
-#: src/preferences/locationsPage.js:593
-#, javascript-format
-msgid "Are you sure you want to delete \"%s\"?"
-msgstr "Você tem certeza que quer apagar \"%s\"?"
+#: src/preferences/generalPage.js:404
+msgid "Restore Defaults"
+msgstr "Restaurar Padrões"
 
-#: src/preferences/locationsPage.js:601
-msgid "Delete"
-msgstr "Apagar"
+#: src/preferences/generalPage.js:406
+msgid "Restore all settings to the defaults."
+msgstr "Restaurar todas as configurações aos padrões."
 
-#: src/preferences/locationsPage.js:605
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: src/preferences/locationsPage.js:634
-#, javascript-format
-msgid "%s has been deleted"
-msgstr "%s foi apagado"
-
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:75
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:76
 msgid "Temperature Unit"
 msgstr "Unidade de temperatura"
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:79
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:80
 msgid "Pressure Unit"
 msgstr "Unidade de pressão"
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:83
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:84
 msgid "Wind Speed Units"
 msgstr "Unidade de velocidade do vento"
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:84
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:85
 msgid ""
 "Choose the units used for wind speed. Allowed values are 'kph', 'mph', 'm/"
 "s', 'knots', 'ft/s' or 'Beaufort'."
@@ -993,177 +1052,187 @@ msgstr ""
 "Escolha as unidades usadas para velocidade do vento. Os valores permitidos "
 "são \"kph\", \"mph\", \"m/s\", \"nós\", 'ft/s\" ou \"Beaufort\"."
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:88
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:89
 msgid "Wind Direction by Arrows"
 msgstr "Direção do vento usando setas"
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:89
-#, fuzzy
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:90
 msgid "True to display wind direction through arrows rather than letters."
 msgstr "Escolha se quer exibir a direção do vento através de setas ou letras."
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:94
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:95
 #, fuzzy
 msgid "DEPRECATED, City to be displayed"
 msgstr "Cidade a ser mostrada"
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:98
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:99
 msgid "Index of the city to display by default."
-msgstr ""
+msgstr "Índice da cidade a ser exibida por padrão."
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:106
-msgid "OpenWeatherMap Multilingual Support (weather descriptions only)"
-msgstr "Suporte multilingual do OpenWeatherMap (descrições do clima)"
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:107
+msgid "Provider multilingual Support (weather descriptions only)"
+msgstr "Suporte multi-idiomas do Provedor (descrições do clima)"
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:114
-#, fuzzy
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:115
 msgid "True to show temperature in the panel"
 msgstr "Mostrar a temperatura no painel"
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:118
-#, fuzzy
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:119
 msgid "True to show conditions in the panel."
 msgstr "Mostrar as condições do clima no painel"
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:126
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:127
 msgid "Conditions in Forecast"
 msgstr "Condições na previsão"
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:130
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:134
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:131
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:135
 msgid "Position in Panel"
 msgstr "Posição no painel"
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:138
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:139
 msgid "Horizontal position of menu-box."
 msgstr "Posição horizontal da caixa de menu."
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:142
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:143
 msgid "Refresh interval (actual weather)"
 msgstr "Intervalo de atualização (clima atual)"
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:146
-#, fuzzy
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:147
 msgid "Maximum length of the location text"
 msgstr "Tamanho máximo do texto de localização"
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:150
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:151
 msgid "Refresh interval (forecast)"
 msgstr "Intervalo de atualização (previsão)"
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:154
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:155
 msgid "Center forecastbox."
 msgstr "Previsão central."
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:158
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:159
 msgid "Always keep forecast expanded"
-msgstr "MAnter a previsão extendida"
+msgstr "Manter a previsão extendida"
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:162
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:163
 msgid "Number of days in forecast"
 msgstr "Número de dias de previsão"
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:166
-#, fuzzy
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:167
 msgid "Maximum number of digits after the decimal point for temperature"
-msgstr "Numero máximo de dígitos decimais no painel"
+msgstr "Numero máximo de dígitos decimais para a temperatura no painel"
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:170
-#, fuzzy
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:171
 msgid "Maximum number of digits after the decimal point for pressure"
-msgstr "Numero máximo de dígitos decimais no painel"
+msgstr "Numero máximo de dígitos decimais para a pressão no painel"
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:174
-#, fuzzy
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:175
 msgid "Maximum number of digits after the decimal point for wind speed"
-msgstr "Numero máximo de dígitos decimais no painel"
+msgstr "Numero máximo de dígitos decimais para a velocidade do vento no painel"
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:178
-msgid "Your personal API key from openweathermap.org"
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:180
+msgid "DEPRECATED. Your personal API key from openweathermap.org"
 msgstr "API key pessoal do openweathermap.org"
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:182
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:185
 #, fuzzy
-msgid "Your personal API key from WeatherAPI.com"
+msgid "DEPRECATED. Your personal API key from WeatherAPI.com"
 msgstr "API key pessoal do openweathermap.org"
-
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:186
-msgid "Use the extensions default API key from openweathermap.org"
-msgstr "Use a API key padrão da extensão do openweathermap.org"
 
 #: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:190
 #, fuzzy
-msgid "Use the extensions default API key from WeatherAPI.com"
+msgid "DEPRECATED. Use the extensions default API key from openweathermap.org"
 msgstr "Use a API key padrão da extensão do openweathermap.org"
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:194
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:195
+#, fuzzy
+msgid "DEPRECATED. Use the extensions default API key from WeatherAPI.com"
+msgstr "Use a API key padrão da extensão do openweathermap.org"
+
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:199
 msgid "Your personal AppKey from developer.mapquest.com"
 msgstr "AppKey pessoal do developer.mapquest.com"
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:198
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:203
 msgid ""
 "Time format for hours. Possible values are '24hr' for 24-hour clock, '12hr' "
 "for AM/PM, and 'system' to follow the GNOME setting."
 msgstr ""
+"Formato para as horas. Valores possíveis são '24 horas', '12 horas', "
+"e 'Sistema' para seguir a configuração do GNOME."
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:202
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:207
 msgid "Seconds to delay popup initialization and data fetch on the first load"
 msgstr ""
 "Segundos de atraso do popup e de atualização de dados durante a incialização"
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:206
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:211
 msgid "Default width for the preferences window"
 msgstr "Largura padrão da janela de preferências"
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:210
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:215
 msgid "Default height for the preferences window"
 msgstr "Altura padrão da janela de preferêcias"
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:214
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:219
 msgid ""
 "High contrast style to use, possible values are 'none', 'white', or 'black'."
 msgstr ""
+"Estilo de alto contraste a ser utilizado, valores possíveis são 'desligado', 'branco', ou 'preto'."
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:218
-#, fuzzy
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:223
 msgid "True to show the sunset/sunrise in the panel."
-msgstr "Mostrar a temperatura no painel"
+msgstr "Mostrar o nascer/pôr do sol no painel."
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:222
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:227
 msgid ""
 "True to show the sunset/sunrise in the panel before the temperature/"
 "conditions if enabled."
-msgstr ""
+msgstr "Mostrar nascer/pôr do sol no painel antes da temperatura/condições."
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:226
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:231
 msgid "False if this extension has never been initialized before."
-msgstr ""
+msgstr "Falso caso a extensão nunca foi inicializada."
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:230
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:235
 msgid "How often, in minutes, to re-fetch My Location if selected."
-msgstr ""
+msgstr "" 
+"Frequência, em minutos, para buscar novamente os dados de "
+"localização."
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:234
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:239
 msgid "True to cut off the \"F\" or \"C\" after the degree symbol."
-msgstr ""
-
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:238
-msgid "Freezes the settings changed listener; user should not change this."
-msgstr ""
+msgstr "Retirar o 'F' ou 'C' após o símbolo de graus."
 
 #: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:243
-#, fuzzy
-msgid "List of locations."
-msgstr "Locais"
+msgid "Freezes the settings changed listener; user should not change this."
+msgstr "Congela o listener de configurações; usuário não deve alterar."
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:247
-#, fuzzy
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:248
+msgid "List of locations."
+msgstr "Lista de locais."
+
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:252
 msgid "Provider to use for \"My Location.\""
 msgstr "Provedor utilizado para os dados de localização"
 
-#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:251
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:256
 msgid "Empty or the last initialization error message."
-msgstr ""
+msgstr "Vazio ou mensagem de erro da última inicialização."
+
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:260
+msgid "Custom keys for weather providers."
+msgstr "Chaves customizadas para provedores de clima."
+
+#: schemas/org.gnome.shell.extensions.openweatherrefined.gschema.xml:264
+msgid "Get a notification when precipitation starts."
+msgstr "Receba uma notificação quando começar a precipitar."
+
+#~ msgid "Today Only"
+#~ msgstr "Apenas hoje"
+
+#~ msgid "5"
+#~ msgstr "5"
 
 #~ msgid "Thunderstorm with Light Rain"
 #~ msgstr "Temporal com chuva leve"

--- a/src/preferences/generalPage.js
+++ b/src/preferences/generalPage.js
@@ -68,7 +68,7 @@ class GeneralPage extends Adw.PreferencesPage
   constructor(metadata, settings, wnd)
   {
     super({
-      title: "Settings",
+      title: _("Settings"),
       icon_name: "preferences-system-symbolic",
       name: "GeneralPage",
     });


### PR DESCRIPTION
# Changelog

- **Add** missing gettext entry for the **Settings**;
- **Update** openweather.pot file;
- **Add** translations for Brazilian Portuguese with the updated references.