### PR TITLE
Update Forecast styles

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -1805,7 +1805,7 @@ class OpenWeatherMenuButton extends PanelMenu.Button {
     this._todaysBox = new St.BoxLayout({
       x_expand: true,
       x_align: this._center_forecast
-        ? Clutter.ActorAlign.END
+        ? Clutter.ActorAlign.CENTER
         : Clutter.ActorAlign.START,
       style_class: "openweather-today-box",
     });

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -101,18 +101,18 @@
 
 .openweather-today-databox {
 	text-align: center;
-	padding-right: 35px;
-	padding-left: 35px;
+	padding-right: 15px;
+	padding-left: 15px;
 }
 
 .openweather-forecast-databox {
 	text-align: center;
-	min-width: 180px;
-	min-height: 120px;
+	min-width: 150px;
+	min-height: 100px;
 }
 
 .openweather-forecast-day {
-	min-height: 120px;
+	min-height: 100px;
 	padding: 0px 2px 0px 0px;
 	text-align: right;
 	font-weight: bold;


### PR DESCRIPTION
##  Summary
Updated some of the CSS styles to be a bit more pleasant in my opinion.

## Changelog
- Fix **Centralize Forecast** option that was actually aligning it to the end instead of the center (**Red border**).
- Reduced the **padding-left** and **padding-right** properties of the 'today-databox' (**Red border**).  Now they're closer to each other.
- Reduced the **min-height/min-width** properties of the 'forecast-databox' (**Green border**) and the 'forecast-day' (**Violet border**). Now they're not so distant from one another.

![OpenWeatherRefined-markup-lines](https://github.com/user-attachments/assets/13c516f0-f34d-45b7-b8aa-85cfa31aa0a8)

---
## Examples
Some examples without the border lines in a few languages:

### English:  
![OpenWeatherRefined-english](https://github.com/user-attachments/assets/737838d8-a948-4dfb-80bc-2eb0ec88d250)

### Portuguese:
![OpenWeatherRefined-portuguese](https://github.com/user-attachments/assets/dbd0362e-a660-4886-aefa-a870f0cb67b1)


### Greek:
![OpenWeatherRefined-greek](https://github.com/user-attachments/assets/5651dcfd-508d-41dc-ae73-b783bc855a0b)

### German:
![OpenWeatherRefined-german](https://github.com/user-attachments/assets/44386d25-887b-4762-b391-752f04c2d583)
