### PR TITLE
Fix repeat of day in forecast view

### DIFF
--- a/src/getweather.js
+++ b/src/getweather.js
@@ -573,7 +573,7 @@ export class Weather
 
       let distanceHrs = (future - d[0].getStart().getTime()) / 3600000;
       let index = Math.ceil(distanceHrs / h.getDurationHours());
-      if(index >= this.#forecasts[i].length) index = this.#forecasts[i].length - 1;
+      if(index >= this.#forecasts[i].length) continue;
       return this.#forecasts[i][index];
     }
 


### PR DESCRIPTION
When using openweathermap, the previous code would repeat the forecast for a time slot when the forecast data would roll over from one day into the next. This pr fixes that issue by letting the loop go onto the next iteration to pick up the data from the first index of the next day.

Example of the issue:
![error](https://github.com/user-attachments/assets/3503cb83-f178-45fb-8469-e29a9bf3e8b1)
Fixed:
![fixed](https://github.com/user-attachments/assets/d60eef39-080d-4f28-b2b2-f80b5c45c39d)

This may address #30