### PR TITLE
Fix sunrise sunset display

### DIFF
--- a/src/getweather.js
+++ b/src/getweather.js
@@ -817,26 +817,12 @@ export async function getWeatherInfo(extension, gettext)
         let m = json.main;
         let iconId = json.weather[0].icon;
 
-        // OpenWeatherMap bug? Sunrise/sunset seconds seems to always return
-        // for same day even if sunrise is tomorrow morning. Therefore just
-        // subtract today and we'll decide if it's tomorrow or not
-        let thisMorningMs = new Date().setHours(0, 0, 0, 0);
-        let midnightMs = thisMorningMs + 3600000 * 24;
-        let sunriseMs = json.sys.sunrise * 1000 - thisMorningMs;
-        let sunsetMs = json.sys.sunset * 1000 - thisMorningMs;
+        let sunriseMs = json.sys.sunrise * 1000;
+        let sunsetMs = json.sys.sunset * 1000;
 
         let sunrise, sunset;
-        // "pod" = Part of Day, "d" = day, "n" = night
-        if(forecastResponse[1].list[0].sys.pod === "d")
-        {
-          sunrise = new Date(sunriseMs + midnightMs);
-          sunset  = new Date(sunsetMs  + thisMorningMs);
-        }
-        else
-        {
-          sunrise = new Date(sunriseMs + thisMorningMs);
-          sunset  = new Date(sunsetMs  + midnightMs);
-        }
+        sunrise = new Date(sunriseMs);
+        sunset = new Date(sunsetMs);
 
         let forecastDays = clamp(1, extension._days_forecast + 1, 5);
         extension._forecastDays = forecastDays - 1;
@@ -943,24 +929,13 @@ export async function getWeatherInfo(extension, gettext)
 
         const KPH_TO_MPS = 1.0 / 3.6;
 
-        // Just a time is returned, we need to figure out if that time is
-        // today or tomorrow
         let thisMorningMs = new Date().setHours(0, 0, 0, 0);
-        let midnightMs = thisMorningMs + 3600000 * 24;
-        let sunriseMs = timeToMs(astro.sunrise);
-        let sunsetMs = timeToMs(astro.sunset);
+        let sunriseMs = timeToMs(astro.sunrise) + thisMorningMs;
+        let sunsetMs = timeToMs(astro.sunset) + thisMorningMs;
 
         let sunrise, sunset;
-        if(m.is_day)
-        {
-          sunrise = new Date(sunriseMs + midnightMs);
-          sunset  = new Date(sunsetMs  + thisMorningMs);
-        }
-        else
-        {
-          sunrise = new Date(sunriseMs + thisMorningMs);
-          sunset  = new Date(sunsetMs  + midnightMs);
-        }
+        sunrise = new Date(sunriseMs);
+        sunset = new Date(sunsetMs);
 
         let gotDaysForecast = json.forecast.forecastday.length;
         let forecastDays = clamp(1, extension._days_forecast + 1, gotDaysForecast);

--- a/src/getweather.js
+++ b/src/getweather.js
@@ -393,6 +393,7 @@ export class Weather
 
   #sunrise;
   #sunset;
+  #sunriseTomorrow;
 
   #forecasts;
 
@@ -408,9 +409,10 @@ export class Weather
     * @param {string} condition
     * @param {Date} sunrise
     * @param {Date} sunset
+    * @param {Date} sunriseTomorrow
     * @param {(Forecast[][] | null)} forecasts
     */
-  constructor(tempC, feelsLikeC, humidityPercent, pressureMBar, windMps, windDirDeg, gustsMps, iconName, condition, sunrise, sunset, forecasts = null)
+  constructor(tempC, feelsLikeC, humidityPercent, pressureMBar, windMps, windDirDeg, gustsMps, iconName, condition, sunrise, sunset, sunriseTomorrow = null, forecasts = null)
   {
     this.#tempC = tempC;
     this.#feelsLikeC = feelsLikeC;
@@ -422,6 +424,7 @@ export class Weather
     this.#iconName = iconName;
     this.#sunrise = sunrise;
     this.#sunset = sunset;
+    this.#sunriseTomorrow = sunriseTomorrow
     this.#forecasts = forecasts ? forecasts.length > 0 ? forecasts : null : null;
 
     if(typeof condition === "string") this.#condition = condition;
@@ -515,6 +518,22 @@ export class Weather
   getSunriseDate()
   {
     return this.#sunrise;
+  }
+
+  /**
+    * @returns {string}
+    */
+  displaySunriseTomorrow(extension)
+  {
+    return extension.formatTime(this.#sunriseTomorrow);
+  }
+
+  /**
+    * @returns {Date}
+    */
+  getSunriseTomorrowDate()
+  {
+    return this.#sunriseTomorrow;
   }
 
   /**
@@ -855,7 +874,8 @@ export async function getWeatherInfo(extension, gettext)
                 getIconName(WeatherProvider.OPENWEATHERMAP, fIconId, isFNight, true),
                 getCondit(extension, h.weather[0].id, h.weather[0].description, gettext),
                 sunrise,
-                sunset
+                sunset,
+                sunrise
               )
             ));
           }
@@ -874,6 +894,7 @@ export async function getWeatherInfo(extension, gettext)
           getCondit(extension, json.weather[0].id, json.weather[0].description, gettext),
           sunrise,
           sunset,
+          sunrise,
           forecasts
         );
       }
@@ -964,7 +985,8 @@ export async function getWeatherInfo(extension, gettext)
                 getIconName(WeatherProvider.WEATHERAPICOM, h.condition.code, !h.is_day, true),
                 getCondit(extension, h.condition.code, h.condition.text, gettext),
                 sunrise,
-                sunset
+                sunset,
+                sunrise
               )
             ));
           }
@@ -983,6 +1005,7 @@ export async function getWeatherInfo(extension, gettext)
           getCondit(extension, m.condition.code, m.condition.text, gettext),
           sunrise,
           sunset,
+          sunrise,
           forecasts
         );
       }
@@ -1036,6 +1059,7 @@ export async function getWeatherInfo(extension, gettext)
         {
           let day = [ ];
           let d = json.days[i];
+
           for(let j = 0; j < d.hours.length; j++)
           {
             let h = d.hours[j];
@@ -1058,7 +1082,8 @@ export async function getWeatherInfo(extension, gettext)
                 getIconName(WeatherProvider.VISUALCROSSING, h.icon, h.icon.endsWith("-night"), true),
                 gettext(h.conditions),
                 hSunriseDt,
-                hSunsetDt
+                hSunsetDt,
+                hSunriseDt
               )
             ));
           }
@@ -1068,6 +1093,7 @@ export async function getWeatherInfo(extension, gettext)
         let m = json.currentConditions;
         let sunriseDt = new Date(m.sunriseEpoch * 1000);
         let sunsetDt = new Date(m.sunsetEpoch * 1000);
+        let sunriseTomorrowDt = new Date(json.days[1].sunriseEpoch * 1000);
 
         return new Weather(
           m.temp,
@@ -1082,6 +1108,7 @@ export async function getWeatherInfo(extension, gettext)
           gettext(m.conditions),
           sunriseDt,
           sunsetDt,
+          sunriseTomorrowDt,
           forecasts
         );
       }

--- a/src/getweather.js
+++ b/src/getweather.js
@@ -814,7 +814,7 @@ export async function getWeatherInfo(extension, gettext)
           let cur = loadJsonAsync("https://api.openweathermap.org/data/2.5/weather", params);
           let fore = loadJsonAsync("https://api.openweathermap.org/data/2.5/forecast", params);
           let daily = loadJsonAsync("https://api.openweathermap.org/data/2.5/forecast/daily", params);
-          let allResp = await Promise.all([ cur, fore, daily]);
+          let allResp = await Promise.all([ cur, fore, daily ]);
           response = allResp[0];
           forecastResponse = allResp[1];
           dailyResponse = allResp[2];

--- a/src/getweather.js
+++ b/src/getweather.js
@@ -424,7 +424,7 @@ export class Weather
     this.#iconName = iconName;
     this.#sunrise = sunrise;
     this.#sunset = sunset;
-    this.#sunriseTomorrow = sunriseTomorrow
+    this.#sunriseTomorrow = sunriseTomorrow;
     this.#forecasts = forecasts ? forecasts.length > 0 ? forecasts : null : null;
 
     if(typeof condition === "string") this.#condition = condition;

--- a/src/openweathermap.js
+++ b/src/openweathermap.js
@@ -152,7 +152,7 @@ function populateCurrentUI()
         this.topBoxSunIcon.set_gicon(this.getGIcon("daytime-sunrise-symbolic"));
         this.topBoxSunInfo.text = w.displaySunrise(this);
       }
-      else if (ms > sunrise.getTime() && ms < sunset.getTime())
+      else if (ms < sunset.getTime())
       {
         this.topBoxSunIcon.set_gicon(this.getGIcon("daytime-sunset-symbolic"));
         this.topBoxSunInfo.text = w.displaySunset(this);

--- a/src/openweathermap.js
+++ b/src/openweathermap.js
@@ -146,10 +146,8 @@ function populateCurrentUI()
       let sunset = w.getSunsetDate();
       let lastBuild = new Date();
 
-      // Is sunset approaching before the sunrise?
       let ms = lastBuild.getTime();
-      if(sunrise.getTime() - ms > sunset.getTime() - ms)
-      {
+      if (ms > sunrise.getTime() && ms < sunset.getTime()) {
         this.topBoxSunIcon.set_gicon(this.getGIcon("daytime-sunset-symbolic"));
         this.topBoxSunInfo.text = w.displaySunset(this);
       }

--- a/src/openweathermap.js
+++ b/src/openweathermap.js
@@ -147,11 +147,13 @@ function populateCurrentUI()
       let lastBuild = new Date();
 
       let ms = lastBuild.getTime();
-      if (ms < sunrise.getTime()) {
+      if (ms < sunrise.getTime())
+      {
         this.topBoxSunIcon.set_gicon(this.getGIcon("daytime-sunrise-symbolic"));
         this.topBoxSunInfo.text = w.displaySunrise(this);
       }
-      else if (ms > sunrise.getTime() && ms < sunset.getTime()) {
+      else if (ms > sunrise.getTime() && ms < sunset.getTime())
+      {
         this.topBoxSunIcon.set_gicon(this.getGIcon("daytime-sunset-symbolic"));
         this.topBoxSunInfo.text = w.displaySunset(this);
       }

--- a/src/openweathermap.js
+++ b/src/openweathermap.js
@@ -147,14 +147,18 @@ function populateCurrentUI()
       let lastBuild = new Date();
 
       let ms = lastBuild.getTime();
-      if (ms > sunrise.getTime() && ms < sunset.getTime()) {
+      if (ms < sunrise.getTime()) {
+        this.topBoxSunIcon.set_gicon(this.getGIcon("daytime-sunrise-symbolic"));
+        this.topBoxSunInfo.text = w.displaySunrise(this);
+      }
+      else if (ms > sunrise.getTime() && ms < sunset.getTime()) {
         this.topBoxSunIcon.set_gicon(this.getGIcon("daytime-sunset-symbolic"));
         this.topBoxSunInfo.text = w.displaySunset(this);
       }
       else
       {
         this.topBoxSunIcon.set_gicon(this.getGIcon("daytime-sunrise-symbolic"));
-        this.topBoxSunInfo.text = w.displaySunrise(this);
+        this.topBoxSunInfo.text = w.displaySunriseTomorrow(this);
       }
 
       let weatherInfoC = "";


### PR DESCRIPTION
This consists of:

* 61e1994c4db25dbd924954c946801ce1624dcf0c which fixes the logic of the display of sunrise vs. sunset, but it is a little off because if we are after dark, we would be displaying the time of today's sunrise instead of the next sunrise time, which is tomorrow's sunrise time.
* a244538faee7a12548f8048fcd47017482282068 uses the sunrise tomorrow correctly but only for visual crossing
* ac6dc296a55a3e60533d0802b25798a7a8719287 uses the sunrise tomorrow correctly for openweathermap and weatherApi